### PR TITLE
fix: Proxy web-app through nginx

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -134,8 +134,6 @@ services:
   web-app:
     build: ./web-app
     restart: always
-    ports:
-      - "4321:4321"
     depends_on:
       - stores
     develop:

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -9,7 +9,11 @@ http {
         listen       80;
 
         location / {
-            proxy_pass http://web-app/;
+            proxy_pass http://web-app:4321/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_read_timeout 86400;
         }
 
         location /api/account {


### PR DESCRIPTION
This commit removes the port mapping for the `web-app` service and
configures nginx to act as a reverse proxy. This setup improves security
and allows for more flexible routing in the future.  The proxy now
correctly forwards websocket connections and sets a longer read timeout
to handle long-lived connections.
