### PR TITLE
fix(stores)!: Correct image file extensions and update Inca Kola image

### DIFF
--- a/stores/src/initialStores.json
+++ b/stores/src/initialStores.json
@@ -4,7 +4,7 @@
     "cityName": "New York",
     "storeName": "Pollo Bravo",
     "category": "Restaurant",
-    "image": "/api/store/images/polloBravos.jpg",
+    "image": "/api/store/images/polloBravos.jpeg",
     "products": [
       {
         "dishName": "Pollo a la brasa",
@@ -23,7 +23,7 @@
       },
       {
         "dishName": "Inca Kola",
-        "image": "/api/store/images/incaKola",
+        "image": "/api/store/images/incaKola.webp",
         "price": 2.99
       },
       {


### PR DESCRIPTION
This commit corrects the file extensions for the Pollo Bravo store image and updates the Inca Kola product image.  Specifically, the Pollo Bravo image extension is changed from `.jpg` to `.jpeg`, and the Inca Kola image is updated to a `.webp` format. This improves image handling and potentially reduces file sizes.
