### PR TITLE
fix: Correct order service endpoint path

### DIFF
--- a/order/src/index.ts
+++ b/order/src/index.ts
@@ -39,7 +39,7 @@ client
 app.use(express.json());
 app.use(morgan("dev"));
 
-app.post("/", (req, res) => {
+app.post("/order", (req, res) => {
   let payload: typeof OrderSchema._type;
 
   try {
@@ -65,7 +65,7 @@ app.post("/", (req, res) => {
     });
 });
 
-app.get("/", (req, res) => {
+app.get("/order", (req, res) => {
   const accountId = req.query.accountId as string;
 
   const db = client.db("order");

--- a/reverse-proxy/nginx.conf
+++ b/reverse-proxy/nginx.conf
@@ -41,7 +41,7 @@ http {
         }
 
         location /api/order {
-            proxy_pass http://order:3000/;
+            proxy_pass http://order:3000/order;
         }
     }
 }


### PR DESCRIPTION
The order service endpoint was incorrectly configured as `/`, causing
issues when query parameters were passed. This commit changes the
endpoint to `/order` for both POST and GET requests, resolving the
issue.  The reverse proxy configuration was also updated to reflect this
change.
