### PR TITLE
fix: Ensure reverse proxy always restarts

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -109,6 +109,7 @@ services:
 
   reverse-proxy:
     build: ./reverse-proxy
+    restart: always
     ports:
       - "80:80"
     depends_on:


### PR DESCRIPTION
This commit ensures that the reverse proxy container always restarts.
The `restart: always` option has been added to the `reverse-proxy`
service definition in the `docker-compose.yml` file. This prevents
issues where the proxy might not automatically restart after a container
failure or other unexpected events.
