### PR TITLE
fix(stores): Prevent NoSQL injection in store retrieval

### DIFF
--- a/stores/src/index.ts
+++ b/stores/src/index.ts
@@ -50,7 +50,7 @@ app.get("/store", async (req, res) => {
   const db = client.db("store");
   const collection = db.collection("stores");
 
-  const query = cityName ? { cityName } : {}; // If cityName is provided, filter by cityName, else return all
+  const query = cityName ? { cityName: { $eq: cityName } } : {}; // If cityName is provided, filter by cityName, else return all
   const options = {};
 
   const stores = await collection.find(query, options).toArray();


### PR DESCRIPTION
This commit addresses a potential NoSQL injection vulnerability in the `/store` endpoint.  The query parameter was previously vulnerable to injection.  This change ensures that the `cityName` parameter is correctly sanitized and used within the MongoDB query using the `$eq` operator to prevent any malicious input from directly influencing the query.