### PR TITLE
feat: Expand store data and improve image generation

### DIFF
--- a/stores/data/stores.json
+++ b/stores/data/stores.json
@@ -1,812 +1,4400 @@
 [
   {
-    "cityName": "Rome",
-    "storeName": "Bella Vita Ristorante",
-    "category": "Italian",
-    "products": [
-      {
-        "dishName": "Spaghetti Aglio e Olio",
-        "price": 12.95,
-        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/10/aglio-e-olio-recipe-2023-7.jpg"
-      },
-      {
-        "dishName": "Bruschetta",
-        "price": 8.5,
-        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/07/bruschetta-2.jpg"
-      },
-      {
-        "dishName": "Fettuccine Alfredo",
-        "price": 15.99,
-        "image": "https://www.modernhoney.com/wp-content/uploads/2018/08/Fettuccine-Alfredo-Recipe-1.jpg"
-      },
-      {
-        "dishName": "Chicken Parmesan",
-        "price": 14.95,
-        "image": "https://tastesbetterfromscratch.com/wp-content/uploads/2023/03/Chicken-Parmesan-1.jpg"
-      },
-      {
-        "dishName": "Caprese Salad",
-        "price": 10,
-        "image": "https://natashaskitchen.com/wp-content/uploads/2019/08/Caprese-Salad-6.jpg"
-      }
-    ],
-    "image": "https://images.getbento.com/accounts/3115d88f6dd9f20c4e4c792bb0373609/media/images/6757Vita_Bella_15_.png",
-    "storeId": 1
-  },
-  {
-    "cityName": "Milan",
-    "storeName": "Ristorante Bella Vita",
-    "category": "Italian",
-    "products": [
-      {
-        "dishName": "Risotto con Frutti di Mare",
-        "price": 32.5,
-        "image": "https://giadzy.com/cdn/shop/articles/Risotto_Ai_Frutti_Di_Mare_2.jpg?v=1694009813"
-      },
-      {
-        "dishName": "Pollo alla Cacciatora",
-        "price": 18,
-        "image": "https://www.thepetitecook.com/wp-content/uploads/2022/05/pollo-alla-cacciatora.jpg"
-      },
-      {
-        "dishName": "Bruschetta al Pomodoro",
-        "price": 8,
-        "image": "https://www.sandravalvassori.com/wp-content/uploads/2023/09/bruschetta-693.jpg"
-      },
-      {
-        "dishName": "Fettuccine con Funghi e Tartufo",
-        "price": 25,
-        "image": "https://giadzy.com/cdn/shop/articles/IMG_5393-copy-2_1024x.jpg?v=1657170142"
-      },
-      {
-        "dishName": "Panino con Prosciutto e Mozzarella",
-        "price": 12.5,
-        "image": "https://pinabresciani.com/wp-content/uploads/2022/09/DSC00017.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100083677989279",
-    "storeId": 2
-  },
-  {
-    "cityName": "Milan",
-    "storeName": "Bella Vita",
-    "category": "Caffè e Dolci",
-    "products": [
-      {
-        "dishName": "Tiramisù Classico",
-        "price": 6.5,
-        "image": "https://whatsgabycooking.com/wp-content/uploads/2023/12/WGC-Tiramisu-2.jpg"
-      },
-      {
-        "dishName": "Torta di Ricotta e Visciole",
-        "price": 7.9,
-        "image": "https://www.turismoroma.it/sites/default/files/Crostata_1.jpg"
-      },
-      {
-        "dishName": "Cannoli Siciliani",
-        "price": 5,
-        "image": "https://www.caviargiaveri.com/app/uploads/2023/09/ricettacannoli-siciliani-salati-giaveri-c.jpg"
-      },
-      {
-        "dishName": "Panna Cotta con Frutta",
-        "price": 6,
-        "image": "https://lookaside.instagram.com/seo/google_widget/crawler/?media_id=3342772858005639094"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100083150501563",
-    "storeId": 3
-  },
-  {
-    "cityName": "Austin",
-    "storeName": "Bubba's BBQ Shack",
-    "category": "American (Traditional)",
-    "products": [
-      {
-        "dishName": "St. Louis-Style Pork Ribs",
-        "price": 19.99,
-        "image": "https://eatsimplefood.com/wp-content/uploads/2020/04/BBQ-Baby-Back-Pork-Ribs-EatSimpleFood.com_.jpg"
-      },
-      {
-        "dishName": "Dry-Rubbed Brisket",
-        "price": 17.49,
-        "image": "https://i2.wp.com/www.downshiftology.com/wp-content/uploads/2017/05/Brisket-Dry-Rub-Ingredients.jpg"
-      },
-      {
-        "dishName": "BBQ Pulled Pork Sandwich",
-        "price": 10.99,
-        "image": "https://www.allrecipes.com/thmb/-at8j5tk5EdjZUetFMLI9n2Le3E=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/18978-bbq-pork-for-sandwiches-cookinmama-1x1-1-244e3dba9c604f57971c6c39a71a7b1e.jpg"
-      },
-      {
-        "dishName": "Coleslaw",
-        "price": 4.25,
-        "image": "https://www.inspiredtaste.net/wp-content/uploads/2015/01/Coleslaw-Recipe-2-1200.jpg"
-      },
-      {
-        "dishName": "Baked Beans",
-        "price": 3.5,
-        "image": "https://www.allrecipes.com/thmb/LgEM55iZfiRc8eD0sc05BQTb2Ck=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/21519simple-baked-beans-iiYoly4x3-f1ef499249c04f13bf068c6f6ddd1d0f.jpg"
-      }
-    ],
-    "image": "https://biteclubcayman.com/wp-content/uploads/2021/05/BubbasBBQ-Full-color.svg",
-    "storeId": 4
-  },
-  {
-    "cityName": "Beijing",
-    "storeName": "XiangYuan Restaurant",
-    "category": "Chinese",
-    "products": [
-      {
-        "dishName": "Peking Duck",
-        "price": 25.99,
-        "image": "https://redhousespice.com/wp-content/uploads/2022/01/sliced-peking-duck-with-pancakes-scaled.jpg"
-      },
-      {
-        "dishName": "Kung Pao Chicken",
-        "price": 14.95,
-        "image": "https://www.seriouseats.com/thmb/AaMf6tliWc3jh0R-9KLiJG5fzZo=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__serious_eats__seriouseats.com__2014__07__2021-02-12-Take-Out-Kung-Pao-Chicken-MHOM-11-c46f6c06713c45c5a287ddbf08779d04.jpg"
-      },
-      {
-        "dishName": "Stir-Fried Beef with Scallions",
-        "price": 16.49,
-        "image": "https://thewoksoflife.com/wp-content/uploads/2015/10/scallion-beef-stir-fry-2.jpg"
-      },
-      {
-        "dishName": "Wonton Soup",
-        "price": 10.99,
-        "image": "https://iamhomesteader.com/wp-content/uploads/2022/03/wonton-soup-1.jpg"
-      },
-      {
-        "dishName": "Egg Foo Young",
-        "price": 12.95,
-        "image": "https://www.allrecipes.com/thmb/uwbZKXU6mzFEHCHJEIFAOlpsbLg=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/163370-ShrimpEggFooYoung-ddmfs-4X3-0724-bff6046f788b4acaa1692192d130d0ef.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100063693337273",
-    "storeId": 5
-  },
-  {
     "cityName": "New York",
-    "storeName": "Savory Grill",
+    "storeName": "Hunter's Delight",
     "category": "Steakhouses",
     "products": [
       {
-        "dishName": "Grilled Ribeye",
-        "price": 24.99,
+        "dishName": "Grilled Filet Mignon",
+        "price": 32.99,
         "image": "https://www.cookingclassy.com/wp-content/uploads/2022/07/grilled-steak-15.jpg"
       },
       {
-        "dishName": "Beef Tenderloin",
+        "dishName": "Pan-Seared Duck Breast",
         "price": 29.95,
-        "image": "https://www.onceuponachef.com/images/2019/12/Roast-Beef-Tenderloin-9-scaled.jpg"
+        "image": "https://tatyanaseverydayfood.com/wp-content/uploads/2023/02/Pan-Seared-Duck-Breast-with-Plum-Sauce-2.jpg"
       },
       {
-        "dishName": "New York Strip Steak",
-        "price": 26.99,
-        "image": "https://www.billyparisi.com/wp-content/uploads/2018/02/steak-and-potatoes-16.jpg"
+        "dishName": "Venison With Tomato Sauce",
+        "price": 39.99,
+        "image": "https://wildgameandfish.com/wp-content/uploads/2023/12/Venison-Spaghetti-with-Homemade-Spaghetti-Sauce-Recipe.jpg"
       },
       {
-        "dishName": "Filet Mignon",
-        "price": 32.95,
-        "image": "https://silveroak.com/wp-content/uploads/2020/03/Recipe-Peppercorn-Crusted-Filet-Mignon-600x400.jpg"
-      },
-      {
-        "dishName": "Porterhouse",
-        "price": 39.95,
-        "image": "https://assets.bonappetit.com/photos/5ebf05185c440b5a0d6a4f64/1:1/w_2560%2Cc_limit/Steak-Porterhouse-Summer-Au-Poivre-Sauce.jpg"
+        "dishName": "Wild Boar Chops",
+        "price": 34.99,
+        "image": "https://marxfood.com/wp-content/uploads/mf-WildBoarChop-Feature-1200x800.jpg"
       }
     ],
-    "image": "https://dq5r178u4t83b.cloudfront.net/wp-content/uploads/sites/86/2018/07/12121931/Savoy-Grill-GR-horizontal-Gold-2021-LR.jpg",
-    "storeId": 6
-  },
-  {
-    "cityName": "San Francisco",
-    "storeName": "Tartine Bakery & Cafe",
-    "category": "Bakery/Cafe",
-    "products": [
-      {
-        "dishName": "Nectarine And Starfruit Tart",
-        "price": 12.95,
-        "image": "https://simmeringstarfruit.com/wp-content/uploads/2023/08/steamed-peaches-4-a.jpg?w=1024"
-      },
-      {
-        "dishName": "Cinnamon Swirl Brioche",
-        "price": 3.75,
-        "image": "https://thepracticalkitchen.com/wp-content/uploads/2024/02/brioche-cinnamon-rolls-6007.jpg"
-      },
-      {
-        "dishName": "Artisanal Baguette",
-        "price": 4.25,
-        "image": "https://tasteofartisan.com/wp-content/uploads/2019/05/French-baguette-recipe-3.jpg"
-      },
-      {
-        "dishName": "Fresh Fruit Salad",
-        "price": 8.95,
-        "image": "https://tastesbetterfromscratch.com/wp-content/uploads/2015/04/Fruit-Salad-1.jpg"
-      },
-      {
-        "dishName": "Quiche Lorraine",
-        "price": 14.5,
-        "image": "https://www.onceuponachef.com/images/2022/03/quiche-lorraine-1-1.jpg"
-      }
-    ],
-    "image": "https://upload.wikimedia.org/wikipedia/commons/0/0a/Tartine_bakery_exterior_in_2006.jpg",
-    "storeId": 7
-  },
-  {
-    "cityName": "Barcelona",
-    "storeName": "Mar i Muntanya",
-    "category": "Spanish Cuisine",
-    "products": [
-      {
-        "dishName": "Seafood Paella",
-        "price": 19.95,
-        "image": "https://www.simplyrecipes.com/thmb/2GMHFcWEHZGOYbT4eoVCAu2uwsw=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2018__07__Seafood-Paella-LEAD-VERTICAL-fc5f1e71baa8484cafa1a106ffaa9c23.jpg"
-      },
-      {
-        "dishName": "Grilled Octopus",
-        "price": 14.5,
-        "image": "https://dominicagourmet.com/wp-content/uploads/2020/07/Grilled-octopus-scaled.jpg"
-      },
-      {
-        "dishName": "Fideuà with Shrimp",
-        "price": 16.75,
-        "image": "https://www.foodandwine.com/thmb/4tPAldlHOh34q7icXbpOUuZRdjU=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/Squid-Shrimp-Fideua-With-Allioli-FT-RECIPE0921-218bc34ff0ca45bdaead193c05b05548.jpg"
-      },
-      {
-        "dishName": "Steamed Mussels",
-        "price": 10.25,
-        "image": "https://www.themediterraneandish.com/wp-content/uploads/2022/11/steamed-mussels-recipe-6.jpg"
-      },
-      {
-        "dishName": "Garlic Shrimp",
-        "price": 15.9,
-        "image": "https://www.allrecipes.com/thmb/us00EX6PHgu4Dwfq9xfH6SyliA0=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/220597-Simple-garlic-shrimp-beauty3x4_38539-63f687e1ec6a41e88dfb5a9c9021e194.jpg"
-      }
-    ],
-    "image": "https://mediaproxy.salon.com/width/1200/height/675/https://media2.salon.com/2010/02/catalan_braised_chicken_and_shrimp_mar_i_muntanya.jpg",
-    "storeId": 8
+    "image": "http://www.countrysmokehouse.com/cdn/shop/files/Hunters_Delight_-_Small_7f42f508-2d3f-41c9-9718-314ac8738fa5.png?v=1732115016&width=1200",
+    "storeId": 1
   },
   {
     "cityName": "New York",
-    "storeName": "Tuscany Italian Restaurant",
-    "category": "Italian",
+    "storeName": "The Fisherman's Table",
+    "category": "Seafood Restaurant",
     "products": [
       {
-        "dishName": "Classic Caesar Salad",
-        "price": 12.99,
-        "image": "https://www.allrecipes.com/thmb/mXZ0Tulwn3x9_YB_ZbkiTveDYFE=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/229063-Classic-Restaurant-Caesar-Salad-ddmfs-4x3-231-89bafa5e54dd4a8c933cf2a5f9f12a6f.jpg"
+        "dishName": "Grilled Swordfish Steak",
+        "price": 24.99,
+        "image": "https://cdn.apartmenttherapy.info/image/upload/f_jpg,q_auto:eco,c_fill,g_auto,w_1500,ar_1:1/k%2FPhoto%2FSeries%2F2021-05-how-to-grilled-swordfish%2F2021-05-12_ATK1519"
       },
       {
-        "dishName": "Vegetarian Wrap",
-        "price": 10.99,
-        "image": "https://www.bowlofdelicious.com/wp-content/uploads/2014/01/veggie-wrap-1.jpg"
-      },
-      {
-        "dishName": "Spaghetti Bolognese",
-        "price": 14.99,
-        "image": "https://www.recipetineats.com/uploads/2018/07/Spaghetti-Bolognese.jpg"
-      },
-      {
-        "dishName": "Garlic Shrimp Pasta",
-        "price": 16.99,
-        "image": "https://littlesunnykitchen.com/wp-content/uploads/2020/09/Garlic-Shrimp-Pasta-15.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100063864980865",
-    "storeId": 9
-  },
-  {
-    "cityName": "Krakow",
-    "storeName": "Pierogi Palace",
-    "category": "Polish Cuisine",
-    "products": [
-      {
-        "dishName": "Classic Potato & Cheese Pierogi",
-        "price": 8.99,
-        "image": "https://eatingeuropean.com/wp-content/uploads/2014/12/pierogi-13.jpg"
-      },
-      {
-        "dishName": "Sauerkraut & Mushroom Pierogi",
-        "price": 9.49,
-        "image": "https://www.polana.com/cdn/shop/products/mushroom.jpg?v=1629368690"
-      },
-      {
-        "dishName": "Blueberry & Strawberry Pierogi (Dessert)",
-        "price": 7.99,
-        "image": "https://polishfeast.com/wp-content/uploads/Polish-Strawberry-Pierogi.jpg"
-      },
-      {
-        "dishName": "Goat Cheese & Spinach Pierogi",
-        "price": 10.99,
-        "image": "http://www.olitorykitchen.co.uk/cdn/shop/products/IMG20220325130920-_1_7f201ba6-1a0f-40b4-8485-6e0cbf7dc07b.jpg?v=1716298340"
-      },
-      {
-        "dishName": "Pierogi Ruskie (Potato & Cheese with Sour Cream)",
-        "price": 9.99,
-        "image": "https://www.thespruceeats.com/thmb/sSomOn_nkkb2RpQBDE610hlY8ZM=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/potato-cheese-pierogi-recipe-1136822-hero-01-56cdc1b3faaf4a72acfca2b22b8e4269.jpg"
-      }
-    ],
-    "image": "https://westsidemarket.org/wp-content/uploads/Pierogi_Palace_2.jpg",
-    "storeId": 10
-  },
-  {
-    "cityName": "Oklahoma City",
-    "storeName": "Tangelo's Bistro",
-    "category": "Café",
-    "products": [
-      {
-        "dishName": "Classic Burger",
-        "price": 12.99,
-        "image": "http://cooksmartsapp.s3-us-west-2.amazonaws.com/meal_photos/1120/20180702-Classic-Cheeseburgers-NM-1.jpg"
-      },
-      {
-        "dishName": "Grilled Chicken Salad",
-        "price": 14.99,
-        "image": "https://www.dinneratthezoo.com/wp-content/uploads/2020/12/grilled-chicken-salad-4.jpg"
-      },
-      {
-        "dishName": "Tangelo Pie",
-        "price": 6.95,
-        "image": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjbMTnPVLnZV1OPzPsSqOjuZ_RUE_kPlqkz-EmnK3tn7czMXp4XmTJaQvVv2bnBC4IMHq1_0_nGywXZ_6gCtblQXp48JLwq_rki74txcXt5JE2jj6NlUWlWvfJemA6l9RCrx6aSHKbtw_U/w640-h478/2014-01-30+12.37.40.jpg"
-      },
-      {
-        "dishName": "Steak Fajitas",
-        "price": 19.99,
-        "image": "https://littlespicejar.com/wp-content/uploads/2016/08/Steak-Fajita-Bowls-with-Garlic-Lime-Rice-4.jpg"
-      },
-      {
-        "dishName": "Veggie Wrap",
-        "price": 10.99,
-        "image": "https://www.bowlofdelicious.com/wp-content/uploads/2014/01/veggie-wrap-1.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=852288402290695",
-    "storeId": 11
-  },
-  {
-    "cityName": "Sydney",
-    "storeName": "Taste Quest Cafe",
-    "category": "Fusion Cuisine",
-    "products": [
-      {
-        "dishName": "Grilled Octopus with Chimichurri",
-        "price": 22.95,
-        "image": "https://images.ctfassets.net/pujs1b1v0165/50qSnPAUuByACBngwcUzVN/9b3fb42d3e961226d94cd7cfb00a6d5d/octopus_chimichurri.jpg?w=1280"
-      },
-      {
-        "dishName": "Pan-Seared Salmon with Lemon Dill Sauce",
-        "price": 31.5,
-        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/06/Pan-Seared-Salmon-with-Dill-Sauce_EXPS_FT23_133878_ST_1117_1.jpg"
-      },
-      {
-        "dishName": "Crispy Duck Breast with Cherry Compote",
-        "price": 29.75,
-        "image": "https://images.squarespace-cdn.com/content/v1/5cb1d7b92727be25696f46de/51e4d792-65e3-4eb6-b95e-c873d5262973/Hotel+Tango+Crispy+Duck+Breast+w+Cherry+Sauce+Close+up.jpg"
-      },
-      {
-        "dishName": "Spicy Shrimp and Chorizo Paella",
-        "price": 28.25,
-        "image": "https://spanishsabores.com/wp-content/uploads/2024/01/Prawn-and-Chorizo-Paella-Featured-2.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100094167364971",
-    "storeId": 12
-  },
-  {
-    "cityName": "Caracas",
-    "storeName": "El Comalito",
-    "category": "Traditional Venezuelan",
-    "products": [
-      {
-        "dishName": "Arepas de Queso",
-        "price": 4.99,
-        "image": "https://i1.wp.com/www.certifiedpastryaficionado.com/wp-content/uploads/2022/03/Colombian-Arepas-con-Queso_IMG_2950.jpg"
-      },
-      {
-        "dishName": "Arepas Fritas con Pollo",
-        "price": 7.99,
-        "image": "https://www.goya.com/media/3540/arepa-with-chicken-and-avocado-arepa-reina-pepiada.jpg?quality=80"
-      },
-      {
-        "dishName": "Arepas de Pabellón Criollo",
-        "price": 8.99,
-        "image": "https://blog.amigofoods.com/wp-content/uploads/2023/05/pabellon-arepa-1.jpg"
-      },
-      {
-        "dishName": "Cachapas con Queso y Chicharrón",
-        "price": 9.99,
-        "image": "https://img.freepik.com/premium-photo/cachapa-stuffed-with-cheese-pork-rinds-typical-venezuelan-food-made-with-corn_203019-28.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100063475961289",
-    "storeId": 13
-  },
-  {
-    "cityName": "Los Angeles",
-    "storeName": "Bella Vita",
-    "category": "Italian",
-    "products": [
-      {
-        "dishName": "Cauliflower Penne",
-        "price": 14.99,
-        "image": "https://www.wellplated.com/wp-content/uploads/2019/10/Cauliflower-Pasta.jpg"
-      },
-      {
-        "dishName": "Spaghetti Bolognese",
-        "price": 16.99,
-        "image": "https://www.recipetineats.com/uploads/2018/07/Spaghetti-Bolognese.jpg"
-      },
-      {
-        "dishName": "Bruschetta",
-        "price": 8.99,
-        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/07/bruschetta-2.jpg"
-      },
-      {
-        "dishName": "Chicken Parmesan",
+        "dishName": "Swordfish And Beef Pie",
         "price": 18.99,
-        "image": "https://tastesbetterfromscratch.com/wp-content/uploads/2023/03/Chicken-Parmesan-1.jpg"
+        "image": "https://andsmallportions.com/wp-content/uploads/2017/03/swordfish-steak-6.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Salmon Fillet",
+        "price": 22.99,
+        "image": "https://www.dinneratthezoo.com/wp-content/uploads/2019/04/pan-seared-salmon-3.jpg"
+      },
+      {
+        "dishName": "Fisherman's Stew (Mussels, Clams, and Scallops)",
+        "price": 19.99,
+        "image": "https://s23209.pcdn.co/wp-content/uploads/2022/11/220223_DD_Easy-Cioppino_053edit-760x1140.jpg"
       }
     ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100083150501563",
-    "storeId": 14
+    "image": "https://media-cdn.tripadvisor.com/media/photo-s/17/16/82/f0/the-fisherman-s-table.jpg",
+    "storeId": 2
   },
   {
-    "cityName": "New York",
-    "storeName": "Pasta e Fagioli",
-    "category": "Italian",
-    "products": [
-      {
-        "dishName": "Spaghetti Carbonara",
-        "price": 14.99,
-        "image": "https://www.cookingclassy.com/wp-content/uploads/2020/10/spaghetti-carbonara-01.jpg"
-      },
-      {
-        "dishName": "Classic Lasagna",
-        "price": 12.95,
-        "image": "https://www.thewholesomedish.com/wp-content/uploads/2018/07/Best-Lasagna-550-500x500.jpg"
-      },
-      {
-        "dishName": "Vegetarian Stuffed Shells",
-        "price": 10.99,
-        "image": "https://fullofplants.com/wp-content/uploads/2023/05/easy-spinach-and-ricotta-vegan-stuffed-shells-15-1400x2100.jpg"
-      },
-      {
-        "dishName": "Bruschetta",
-        "price": 6.95,
-        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/07/bruschetta-2.jpg"
-      },
-      {
-        "dishName": "Garlic and Herb Focaccia",
-        "price": 4.99,
-        "image": "https://www.allrecipes.com/thmb/whBv1HVdlAtCcF4qS0wdjzxZcBw=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/9395365-deliciously-easy-garlic-herb-focaccia-Deb-C-4x3-1-883ee67055084b7880a0730c56e57f3b.jpg"
-      }
-    ],
-    "image": "https://terianncarty.com/wp-content/uploads/2023/04/PASTA-E-FAGIOLI-.jpeg",
-    "storeId": 15
-  },
-  {
-    "cityName": "Los Angeles",
-    "storeName": "Karam's Kitchen",
-    "category": "Middle Eastern Cuisine",
-    "products": [
-      {
-        "dishName": "Assyrian Gruyere Soup",
-        "price": 7.99,
-        "image": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEgV_Xy3-FjU9jx1gG2ubVm56MSNPAF7mfbe3fpbBfHgGTmVgAo-k4t69ODeA6GSg_CtQYA2L405zeQHWWOCWqURyxuDjytmircZG484HfdxKI5HZ8MjDp-fvYjYRc47iG1E49Ovllk6rwgD/s1013/Garlic+onion+soup.jpg"
-      },
-      {
-        "dishName": "Falafel Wrap",
-        "price": 8.49,
-        "image": "https://www.hauteandhealthyliving.com/wp-content/uploads/2022/01/Falafel-Wrap-with-hummus-8.jpg"
-      },
-      {
-        "dishName": "Shawarma Plate",
-        "price": 9.99,
-        "image": "https://www.hungrypaprikas.com/wp-content/uploads/2020/08/Chicken-Shawarma-Plate-blog-2.jpg"
-      },
-      {
-        "dishName": "Hummus with Pita Bread",
-        "price": 6.99,
-        "image": "https://thefoodiediaries.co/wp-content/uploads/2021/03/img_8477_jpg-1.jpg"
-      },
-      {
-        "dishName": "Grilled Halloumi Cheese",
-        "price": 10.99,
-        "image": "https://www.wellplated.com/wp-content/uploads/2013/07/Grilled-Haloumi-Cheese-with-Fresh-Cherry-Salsa-Recipe-1.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=393653529594200",
-    "storeId": 16
-  },
-  {
-    "cityName": "New York",
-    "storeName": "Rice & Spice Bistro",
-    "category": "Sri Lankan Cuisine",
-    "products": [
-      {
-        "dishName": "Crunchy Sri Lankan Stew",
-        "price": 12.99,
-        "image": "https://lookaside.instagram.com/seo/google_widget/crawler/?media_id=3440137844121434008"
-      },
-      {
-        "dishName": "Hoppers with Egg Curry",
-        "price": 10.99,
-        "image": "https://i0.wp.com/www.pepperdelight.com/wp-content/uploads/2021/01/pepper-delight-egg-curry-2.jpg?ssl=1"
-      },
-      {
-        "dishName": "Deviled Rice Bowl",
-        "price": 9.99,
-        "image": "https://www.thegraciouswife.com/wp-content/uploads/2016/05/Deviled-Egg-Potato-Salad-Recipe-9.jpg"
-      },
-      {
-        "dishName": "Lamb Kofta Wrap",
-        "price": 11.49,
-        "image": "https://knifeandsoul.com/wp-content/uploads/2022/01/lamb_kofta_wrap_final_3-683x1024.jpg"
-      }
-    ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100023071309120",
-    "storeId": 17
-  },
-  {
-    "cityName": "New York",
-    "storeName": "Bella Vita",
+    "cityName": "Rome",
+    "storeName": "La Bella Vita",
     "category": "Italian",
     "products": [
       {
         "dishName": "Mushroom Risotto",
-        "price": 24.99,
-        "image": "https://www.simplyrecipes.com/thmb/SRAi5Uh_AGNgq84stLgXlpcmrOw=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/Simply-Recipes-Mushroom-Risotto-LEAD-8-97bfe04179ac417e9599d9f30d6cc801.JPG"
+        "price": 22.95,
+        "image": "https://cdn77-s3.lazycatkitchen.com/wp-content/uploads/2019/11/vegan-mushroom-risotto-close.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken Parmesan",
+        "price": 18.5,
+        "image": "https://cdn-icons-png.flaticon.com/512/4901/4901689.png"
       },
       {
         "dishName": "Vegetarian Lasagna",
-        "price": 19.95,
-        "image": "https://cdn.loveandlemons.com/wp-content/uploads/2023/12/vegetarian-lasagna-scaled.jpg"
+        "price": 19.25,
+        "image": "https://anothertablespoon.com/wp-content/uploads/2017/10/DSC07712.jpg"
       },
       {
-        "dishName": "Spaghetti Bolognese",
-        "price": 16.99,
-        "image": "https://www.recipetineats.com/uploads/2018/07/Spaghetti-Bolognese.jpg"
-      },
-      {
-        "dishName": "Chicken Parmesan",
-        "price": 18.5,
-        "image": "https://tastesbetterfromscratch.com/wp-content/uploads/2023/03/Chicken-Parmesan-1.jpg"
-      },
-      {
-        "dishName": "Cannoli Siciliani",
-        "price": 8.95,
-        "image": "https://www.caviargiaveri.com/app/uploads/2023/09/ricettacannoli-siciliani-salati-giaveri-c.jpg"
+        "dishName": "Spaghetti Carbonara",
+        "price": 20.75,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2023/01/Carbonara_6a.jpg"
       }
     ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100083150501563",
-    "storeId": 18
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 3
   },
   {
-    "cityName": "Tirana",
-    "storeName": "Baba Gano's Kitchen",
-    "category": "Traditional Albanian Cuisine",
+    "cityName": "Portland",
+    "storeName": "Blossom Bistro",
+    "category": "Farm-to-Table",
     "products": [
       {
-        "dishName": "Golden Albanian Stew (Sheperd's Pie variation)",
-        "price": 12.99,
-        "image": "https://i.natgeofe.com/n/f8213b27-c976-4486-8313-22898909811e/Moussaka3.jpg"
+        "dishName": "Chamomile-Rubbed Quail Salad",
+        "price": 22.95,
+        "image": "https://dish.co.nz/assets/media/VERSIONS/images/21-ds0409-095_copy_big__FillWzg1MCwxMTc0XQ.jpg"
       },
       {
-        "dishName": "Qofte Ball (Albanian Meatballs) - Beef & Onion",
-        "price": 8.99,
-        "image": "https://mediterraneanlatinloveaffair.com/wp-content/uploads/2021/02/Albanian-meatballs-qofter-1.jpg"
+        "dishName": "Pan-Seared Wild Salmon",
+        "price": 25.5,
+        "image": "https://www.unicornsinthekitchen.com/wp-content/uploads/2019/11/Pan-seared-salmon.jpg"
       },
       {
-        "dishName": "Tavë Kosi (Grilled Lamb with Yogurt & Herbs)",
-        "price": 15.99,
-        "image": "https://thumbs.dreamstime.com/b/traditional-albanian-tave-kosi-elbasani-delightful-dish-lamb-baked-creamy-yogurt-egg-custard-served-baking-taste-329109540.jpg"
+        "dishName": "Roasted Heirloom Vegetables",
+        "price": 15,
+        "image": "https://s23209.pcdn.co/wp-content/uploads/2014/10/Roasted-VegetablesIMG_0415.jpg"
       },
       {
-        "dishName": "Byrek (Flaky Pastry Pie) - Spinach & Feta",
-        "price": 6.99,
-        "image": "https://balkanbites.co/cdn/shop/products/BalkanBites-2Bureks-Bag-Front-White-BG-Spinach-1500x1500_3_4_1500x.jpg?v=1652229950"
-      },
-      {
-        "dishName": "Ajvar (Roasted Red Pepper Sauce)",
-        "price": 4.99,
-        "image": "https://www.seriouseats.com/thmb/FPNJOk1UM0wDbv8vCiJ0AtdRIWY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__serious_eats__seriouseats.com__recipes__images__2013__09__20130903-265217-ajvar-e5097e43dd1a4ca7ba451d70ff1b1fea.jpg"
+        "dishName": "Grilled Lamb Chops with Mint Jus",
+        "price": 28.95,
+        "image": "https://sharedappetite.com/wp-content/uploads/2017/07/grilled-lamb-chops-with-mint-chimichurri-17-copy-1024x1024.jpg"
       }
     ],
-    "image": "https://galyalovesfood.com/wp-content/uploads/2021/07/galy-shani-galya-loves-food-collage-730w.jpg?w=730",
-    "storeId": 19
+    "image": "https://lirp-cdn.multiscreensite.com/af6fd468/import/clib/bananablossombistro_com/dms3rep/multi/opt/BBB_LogoFiles_Final_BBB_Primary-Logo_fullcolor_coffeecloudtext-1500x1211-1920w.png",
+    "storeId": 4
+  },
+  {
+    "cityName": "Milan",
+    "storeName": "Bella Vita",
+    "category": "Cafe & Bakery",
+    "products": [
+      {
+        "dishName": "Tiramisù Classico",
+        "price": 6.5,
+        "image": "https://www.baking4happiness.com/wp-content/uploads/2020/09/Easy-and-Classic-Tiramisu-Recipe-Original-Italian-1366x2048.jpg"
+      },
+      {
+        "dishName": "Tiramisù con Frutta",
+        "price": 7.2,
+        "image": "https://www.cucchiaio.it/content/cucchiaio/it/ricette/2016/08/tiramisu-con-panna-e-frutta/_jcr_content/header-par/image-single.img.jpg/1470317107682.jpg"
+      },
+      {
+        "dishName": "Tiramisù Gelato",
+        "price": 4.8,
+        "image": "https://blog.giallozafferano.it/curmifood/wp-content/uploads/2018/12/IMG_20200524_140838-2048x1536.jpg"
+      },
+      {
+        "dishName": "Coffee e Panna Cotta",
+        "price": 5.9,
+        "image": "https://bakewithshivesh.com/wp-content/uploads/2023/04/coffee-panna-cotta-1-scaled.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 5
   },
   {
     "cityName": "Tokyo",
-    "storeName": "Sushi Fushia",
+    "storeName": "Sakura Japanese Restaurant",
     "category": "Japanese",
     "products": [
       {
-        "dishName": "Tuna Sashimi",
-        "price": 20,
-        "image": "https://cdn.urbancookery.com/2021/01/tuna_sashimi_2.jpg__1500x0_q85_autocrop_crop-smart_upscale.jpg"
+        "dishName": "Teriyaki Chicken Donburi",
+        "price": 12.99,
+        "image": "https://production-media.gousto.co.uk/cms/mood-image/2260---Teriyaki-chicken-donburi-bowl_Wagamamas-1632-1569588701689.jpg"
       },
       {
-        "dishName": "Salmon Sushi Roll",
-        "price": 18.5,
-        "image": "https://reciperunner.com/wp-content/uploads/2022/04/salmon-roll-sushi-bowls-4.jpg"
+        "dishName": "Tonkatsu Ramen",
+        "price": 14.99,
+        "image": "https://i.pinimg.com/originals/72/ce/4d/72ce4d05d88d303b0478ee054633499b.jpg"
       },
       {
-        "dishName": "Spicy Tuna Roll",
-        "price": 19.8,
-        "image": "https://www.tiger-corporation.com/wp-content/uploads/2023/02/hero-img-recipe-spicy-tuna-3db6e125056f2bde01321a3da5d290da.jpg"
+        "dishName": "Salmon Sushi Rolls",
+        "price": 8.99,
+        "image": "https://tatyanaseverydayfood.com/wp-content/uploads/2014/04/Spicy-Salmon-Sushi-Roll.jpg"
       },
       {
-        "dishName": "California Roll",
-        "price": 17,
-        "image": "https://hungryfoodie.com/wp-content/uploads/2021/04/California-Roll-in-a-Bowl-RecipeIMG_4267.jpg"
+        "dishName": "Yakitori Chicken Skewers",
+        "price": 9.99,
+        "image": "https://www.closetcooking.com/wp-content/uploads/2009/07/Yakitori-Japanese-Grilled-Chicken-Skewers-1200-4319.jpg"
+      },
+      {
+        "dishName": "Miso Soup",
+        "price": 2.49,
+        "image": "https://www.thespruceeats.com/thmb/q5pzZZKO021eP9s4x_-Mq6m_I8Q=/4494x3000/filters:fill(auto,1)/basic-miso-soup-3377886_09-5b3f7fb6c9e77c00378bf68f.jpg"
       }
     ],
-    "image": "https://m.media-amazon.com/images/I/91PydfGOQiL._AC_UY1000_.jpg",
-    "storeId": 20
+    "image": "https://media-cdn.tripadvisor.com/media/photo-s/1a/77/73/36/sakura-logo-2020.jpg",
+    "storeId": 6
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Steakhouse Empire",
+    "category": "Steakhouses",
+    "products": [
+      {
+        "dishName": "Ribeye",
+        "price": 45.99,
+        "image": "https://www.wholesomeyum.com/wp-content/uploads/2022/12/wholesomeyum-Cast-Iron-Ribeye-Steak-Recipe-1.jpg"
+      },
+      {
+        "dishName": "Filet Mignon",
+        "price": 32.95,
+        "image": "https://usercontent1.hubstatic.com/14192394_f1024.jpg"
+      },
+      {
+        "dishName": "New York Strip Steak",
+        "price": 39.99,
+        "image": "https://littlefamilyadventure.com/wp-content/uploads/2021/08/Seared-NY-Strips.jpg"
+      },
+      {
+        "dishName": "Grilled Flank Steak",
+        "price": 24.95,
+        "image": "https://therecipecritic.com/wp-content/uploads/2018/07/grilled-flank-steak-4.jpg"
+      },
+      {
+        "dishName": "Porterhouse Steak",
+        "price": 59.95,
+        "image": "https://i.pinimg.com/originals/73/94/40/739440ba2ac632c2a88b969d95bfdff5.jpg"
+      }
+    ],
+    "image": "https://mark.trademarkia.com/logo-images/rjj-restaurant-llc/empire-steak-house-85150681.jpg",
+    "storeId": 7
+  },
+  {
+    "cityName": "Lucknow",
+    "storeName": "Dastarkhwan",
+    "category": "Indian",
+    "products": [
+      {
+        "dishName": "Awadhi Swiss Chard Soup",
+        "price": 125,
+        "image": "https://healthiersteps.com/wp-content/uploads/2021/09/swiss-chard-soup-1150x1536.jpg"
+      },
+      {
+        "dishName": "Chicken Tikka Biryani",
+        "price": 225,
+        "image": "http://www.cookwithkushi.com/wp-content/uploads/2016/04/IMG_9431_.jpg"
+      },
+      {
+        "dishName": "Rogan Josh with Naan Bread",
+        "price": 195,
+        "image": "https://img.freepik.com/premium-photo/indian-cuisine-curry-sauce-from-rogan-josh-rice-naan-bread-with-pork-rogan-josh_410516-47310.jpg?w=2000"
+      },
+      {
+        "dishName": "Vegetable Korma with Rice",
+        "price": 165,
+        "image": "https://thewanderlustkitchen.com/wp-content/uploads/2016/11/Creamy-Indian-Vegetable-Korma-Recipe-65-1205x1536.jpg"
+      }
+    ],
+    "image": "https://img.restaurantguru.com/r62c-Dastarkhwan-garden-restaurant-logo-2021-09.jpg",
+    "storeId": 8
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Tasty Pastries",
+    "category": "Desserts",
+    "products": [
+      {
+        "dishName": "Apricot And Grape Tart",
+        "price": 8.99,
+        "image": "https://perchancetocook.com/wp-content/uploads/2023/06/Easy-Apricot-Tart-4-1152x1536.jpg"
+      },
+      {
+        "dishName": "Chocolate Mousse Cake",
+        "price": 12.5,
+        "image": "https://disheswithdad.com/wp-content/uploads/2021/01/chocolate-mousse-cake-15.jpg"
+      },
+      {
+        "dishName": "Caramel Pecan Pie",
+        "price": 9.95,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/Caramel-Pecan-Pie_EXPS_HPLBZ18_28086_B05_17_5b-6.jpg"
+      },
+      {
+        "dishName": "Strawberry Cheesecake",
+        "price": 10.25,
+        "image": "https://hips.hearstapps.com/hmg-prod/images/delish-202105-strawberrycheesecake-135-ls-1623955969.jpg?crop=0.668xw:1.00xh;0.167xw,0&resize=1200:*"
+      },
+      {
+        "dishName": "Blueberry Lemon Tarts",
+        "price": 11,
+        "image": "https://sallysbakingaddiction.com/wp-content/uploads/2021/03/lemon-blueberry-tart-shortbread-crust.jpg"
+      }
+    ],
+    "image": "https://rovenlogos.com/wp-content/uploads/2022/03/rovenlogos_tastybakery.png",
+    "storeId": 9
+  },
+  {
+    "cityName": "Austin",
+    "storeName": "El Patio Mexican Grill",
+    "category": "Mexican",
+    "products": [
+      {
+        "dishName": "Chicken Fajitas",
+        "price": 18.99,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2021/04/Chicken-Fajitas-011-scaled.jpg"
+      },
+      {
+        "dishName": "Beef Tacos",
+        "price": 12.95,
+        "image": "https://www.jocooks.com/wp-content/uploads/2020/08/ground-beef-tacos-1-11.jpg"
+      },
+      {
+        "dishName": "Veggie Burrito",
+        "price": 10.5,
+        "image": "https://i2.wp.com/www.splashoftaste.com/wp-content/uploads/2023/04/Veggie-Burritos-featured-997x1536.jpg"
+      },
+      {
+        "dishName": "Carne Asada",
+        "price": 19.99,
+        "image": "https://onedishkitchen.com/wp-content/uploads/2021/08/carne-asada-one-dish-kitchen-1-1200x1801.jpg"
+      },
+      {
+        "dishName": "Quesadillas",
+        "price": 9.95,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2021/04/Chicken-Quesadillas012-scaled.jpg"
+      },
+      {
+        "dishName": "Chile Relleno",
+        "price": 14.99,
+        "image": "https://eatingrichly.com/wp-content/uploads/2018/06/chiles-relleno-authentic-2032-scaled.jpg"
+      },
+      {
+        "dishName": "Guacamole",
+        "price": 8,
+        "image": "https://www.cubesnjuliennes.com/wp-content/uploads/2021/02/Homemade-Guacamole-Recipe.jpg"
+      }
+    ],
+    "image": "https://toast-sites-prod.nyc3.cdn.digitaloceanspaces.com/restaurantImages/9b97da4a-df11-4daa-85f2-12fcfce9c15a/El%20Patio%20Logo.jpg",
+    "storeId": 10
   },
   {
     "cityName": "London",
     "storeName": "The Codfather",
-    "category": "Fish & Seafood",
+    "category": "Fast Food",
     "products": [
       {
-        "dishName": "Cod and Chips",
+        "dishName": "Classic Cod & Chips",
         "price": 10.99,
-        "image": "https://www.thespruceeats.com/thmb/sdVTq0h7xZvJjPr6bE2fhh5M3NI=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/SES-best-fish-and-chips-recipe-434856-hero-01-27d8b57008414972822b866609d0af9b.jpg"
+        "image": "https://youngsseafood.co.uk/wp-content/uploads/2018/10/cod-with-vegetable-chips-scaled.jpg"
       },
       {
-        "dishName": "Haddock and Mushy Peas",
+        "dishName": "Haddock & Mushy Peas",
         "price": 11.49,
-        "image": "http://cookingwithchefbryan.com/wp-content/uploads/2023/05/Fish-and-Chips-with-Mushy-Peas-scaled.jpg"
+        "image": "https://bestrecipesuk.com/wp-content/uploads/2020/05/Haddock-Mint-Mushy-Pea-Fishcakes-2023.jpg"
       },
       {
-        "dishName": "Platter of Fresh Oysters",
-        "price": 14.99,
-        "image": "https://www.bristolfarms.com/getmedia/407d930c-1fb6-46b7-990b-ef00229ff279/blog101-platter-1400"
+        "dishName": "Cod Wrap (Sausage & Fries)",
+        "price": 9.95,
+        "image": "https://www.dianekochilas.com/wp-content/uploads/2017/12/13b-Cod-Wrap-01.jpg"
       },
       {
-        "dishName": "Fisherman's Basket (Cod, Haddock, Plaice)",
-        "price": 16.95,
-        "image": "https://images.squarespace-cdn.com/content/v1/50182a8dc4aa5fb338c47d0b/1429662071701-RXLUNV4MCBYB67SDS58P/fish-basket.png"
-      }
-    ],
-    "image": "https://i.pinimg.com/originals/25/94/98/2594984ca5e11ff9b65b3b3e00822a0e.png",
-    "storeId": 21
-  },
-  {
-    "cityName": "Tokyo",
-    "storeName": "Sakura Bistro",
-    "category": "Japanese Cuisine",
-    "products": [
-      {
-        "dishName": "Buckwheat Noodles-infused Venison",
-        "price": 32.5,
-        "image": "http://katieatthekitchendoor.com/wp-content/uploads/2012/12/2012-11-24-119.jpg"
-      },
-      {
-        "dishName": "Pan-seared Tuna with Yuzu Sauce",
-        "price": 25.99,
-        "image": "https://images.getrecipekit.com/20230920155451-perfectly-20seared-20ahi-20tuna-20-20sizzlefiosh-20x-20-40brightmomentco.jpg?aspect_ratio=4:3&quality=90&"
-      },
-      {
-        "dishName": "Grilled Wagyu Beef with Miso Glaze",
-        "price": 45,
-        "image": "https://images.squarespace-cdn.com/content/v1/5f063187ead18a2e98ba7f9b/e7e988f0-8a00-4662-83d8-bd8b706c88ee/Restaurant+Week+-+Boka+%282%29.jpg"
-      },
-      {
-        "dishName": "Steamed Edamame with Sesame Oil",
-        "price": 8.95,
-        "image": "https://pickledplum.com/wp-content/uploads/2018/09/edamame-with-soy-and-sesame-1200.jpg"
-      },
-      {
-        "dishName": "Spicy Tofu Stir-fry with Udon Noodles",
-        "price": 19.99,
-        "image": "https://thefoodietakesflight.com/wp-content/uploads/2021/03/Vegan-Stir-Fried-Spicy-Garlic-Udon-Noodles-Recipe-23.png"
-      }
-    ],
-    "image": "https://images.squarespace-cdn.com/content/v1/5b8493d296d455a851b348dd/1621217147205-I2WCR7YOHPP71JEO9K5P/sxc_cover.jpg?format=2500w",
-    "storeId": 22
-  },
-  {
-    "cityName": "Lisbon",
-    "storeName": "Restaurante O'Fado",
-    "category": "Portuguese",
-    "products": [
-      {
-        "dishName": "Bacalhau à Brás",
-        "price": 12.5,
-        "image": "https://foodandroad.com/wp-content/uploads/2021/04/bacalhau-bras-1.jpg"
-      },
-      {
-        "dishName": "Carne de Porco à Alentejana",
-        "price": 15,
-        "image": "https://wetravelportugal.com/wp-content/uploads/2020/12/porco-a-alentejana.jpg"
-      },
-      {
-        "dishName": "Arroz de Pato (Duck Rice)",
-        "price": 14.9,
-        "image": "https://www.photosandfood.ca/wp-content/uploads/2021/01/arrozdepato-SSP_193.jpg"
-      },
-      {
-        "dishName": "Cataplana de Peixe",
-        "price": 18.5,
-        "image": "https://www.foodandwine.com/thmb/ZoqM_rpVqIFojBWHoiKDmgwlOjc=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/Cataplana-Portugese-Fish-Stew-FT-RECIPE0522-628492e5ebd6472195934e4418ff6fca.jpg"
-      },
-      {
-        "dishName": "Grilled Sardines with Onions and Potatoes",
-        "price": 10,
-        "image": "https://blog.suvie.com/wp-content/uploads/2022/05/Grilled-Sardine_HERO.jpg"
-      }
-    ],
-    "image": "https://media-cdn.tripadvisor.com/media/photo-s/0f/63/df/b4/preparando-paelleras.jpg",
-    "storeId": 23
-  },
-  {
-    "cityName": "Barcelona",
-    "storeName": "El Olivo",
-    "category": "Spanish Cuisine",
-    "products": [
-      {
-        "dishName": "Smoky Rabbit With Zucchini",
-        "price": 22.99,
-        "image": "https://lookaside.instagram.com/seo/google_widget/crawler/?media_id=3339189290394082636"
-      },
-      {
-        "dishName": "Paella Valenciana",
-        "price": 19.95,
-        "image": "https://www.chocolatesandchai.com/wp-content/uploads/2022/05/Seafood-Paella-Valenciana-Featured.jpg"
-      },
-      {
-        "dishName": "Tortilla de Patatas",
-        "price": 8.5,
-        "image": "https://spanishsabores.com/wp-content/uploads/2023/07/Tortilla-de-Patatas-Featured.jpg"
-      },
-      {
-        "dishName": "Gambas al Ajillo",
+        "dishName": "Fisherman's Basket (Cod, Haddock, Sausage)",
         "price": 16.99,
-        "image": "https://www.foodandwine.com/thmb/6oZOwysQLIXqVUdPJLHrYiuTHSU=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/gambas-al-ajillo-XL-RECIPE0917-05ade57af5194eaeba60a87b258d46f2.jpg"
+        "image": "http://www.foodiesite.com/images/2001-02/fishersmansbasket.jpg"
       },
       {
-        "dishName": "Chuletón de Buey",
-        "price": 29.95,
-        "image": "https://as2.ftcdn.net/v2/jpg/05/68/56/35/1000_F_568563525_JMHDW1AlXpoyfEIc0xYmjHZmVhM1ITmo.jpg"
+        "dishName": "Prawn Cocktail",
+        "price": 12.49,
+        "image": "https://www.sainsburysmagazine.co.uk/media/7155/download/Prawn-cocktail.jpg?v=1"
+      },
+      {
+        "dishName": "Crispy Cod Bites",
+        "price": 8.95,
+        "image": "https://2.bp.blogspot.com/-21nEISrFp20/XA7fwx6_w4I/AAAAAAAA_34/DrdQOE9GC68ABLgvu48uNw7fGr23U7TNgCLcBGAs/s640/Crispy-Fried-Cod-Bites.webp"
+      },
+      {
+        "dishName": "Cod & Chips Meal (Large)",
+        "price": 14.99,
+        "image": "https://seafoodbysykes.com/wp-content/uploads/fish-and-chips-plate-1.jpg"
       }
     ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100057419620432",
-    "storeId": 24
+    "image": "https://www.liblogo.com/img-logo/th7711sf79-the-godfather-logo-simple-color-vinyl-the-godfather-logo-.png",
+    "storeId": 11
   },
   {
-    "cityName": "Honolulu",
-    "storeName": "Poke Paradise",
+    "cityName": "London",
+    "storeName": "The Cod Father",
+    "category": "Fish & Chips",
+    "products": [
+      {
+        "dishName": "Cod & Chips",
+        "price": 8.95,
+        "image": "https://youngsseafood.co.uk/wp-content/uploads/2018/10/cod-with-vegetable-chips-scaled.jpg"
+      },
+      {
+        "dishName": "Haddock & Chips",
+        "price": 9.25,
+        "image": "https://cdn.tasteatlas.com/images/dishes/203b6b37c9b946bea1dd61fc14590af5.jpg?mw=1300"
+      },
+      {
+        "dishName": "Sustainable Cod Burger",
+        "price": 10.5,
+        "image": "https://i.ytimg.com/vi/hNjvT2SchsA/maxresdefault.jpg"
+      },
+      {
+        "dishName": "Battered Sausage & Chips",
+        "price": 8.95,
+        "image": "https://mymorningmocha.com/wp-content/uploads/2022/04/Crispy-Battered-Sausage.jpeg"
+      },
+      {
+        "dishName": "Prawn Cocktail",
+        "price": 12,
+        "image": "https://www.sainsburysmagazine.co.uk/media/7155/download/Prawn-cocktail.jpg?v=1"
+      },
+      {
+        "dishName": "Fisherman's Delight (Haddock, Cod, Prawns)",
+        "price": 18.95,
+        "image": "https://www.clickheateat.com/images/product/main/fishpie1.jpg"
+      }
+    ],
+    "image": "https://www.liblogo.com/img-logo/th7711sf79-the-godfather-logo-simple-color-vinyl-the-godfather-logo-.png",
+    "storeId": 12
+  },
+  {
+    "cityName": "Los Angeles",
+    "storeName": "Bao Haus LA",
     "category": "Asian Fusion",
     "products": [
       {
-        "dishName": "Spicy Tuna Poke Bowl",
-        "price": 12.99,
-        "image": "https://www.skinnytaste.com/wp-content/uploads/2019/08/Spicy-Tuna-Poke-Bowls-8.jpg"
+        "dishName": "Crispy Pork Belly Bun",
+        "price": 8.99,
+        "image": "https://www.unileverfoodsolutions.us/dam/global-ufs/mcos/nam/photography/MultipleBrands/ufs-2023-photoshoot/pork-belly-bao-buns/PorkBellyBao2.jpg"
       },
       {
-        "dishName": "Salmon Sashimi with Yuzu Sauce",
-        "price": 14.95,
-        "image": "https://zarskitchen.com/wp-content/uploads/2021/12/IMG_0588.jpg"
+        "dishName": "Spicy Szechuan Dumplings",
+        "price": 7.49,
+        "image": "https://onolicioushawaii.com/wp-content/uploads/2021/11/szechuan-dumplings-4.jpg"
       },
       {
-        "dishName": "Cajun Shrimp and Veggie Poke",
-        "price": 13.49,
-        "image": "https://onebalancedlife.com/wp-content/uploads/2022/01/Shrimp-Rice-Bowls-768x1024.jpg"
+        "dishName": "Pan-Seared Gyoza",
+        "price": 6.99,
+        "image": "https://static01.nyt.com/images/2019/09/16/dining/kwr-gyoza/merlin_160427046_9e2ab11e-f937-4f2e-a268-4f46b8480c73-threeByTwoMediumAt2X.jpg"
       },
       {
-        "dishName": "Grilled Mahi Mahi with Mango Salsa",
-        "price": 16.99,
-        "image": "https://www.spendwithpennies.com/wp-content/uploads/2021/08/SWP-Grilled-Mahi-Mahi-12.jpg"
+        "dishName": "Miso Soup Ramen",
+        "price": 9.99,
+        "image": "https://i.imgur.com/AtzSX9f.jpg"
       },
       {
-        "dishName": "Spicy Ahi Tuna Wrap",
-        "price": 11.95,
-        "image": "https://lookaside.instagram.com/seo/google_widget/crawler/?media_id=3497656529323638670"
+        "dishName": "Fried Wontons with Sweet Chili Sauce",
+        "price": 5.49,
+        "image": "https://static.vecteezy.com/system/resources/previews/012/131/774/non_2x/crispy-deep-fried-wontons-on-wooden-plate-serve-with-sweet-chilli-sauce-free-photo.jpg"
+      },
+      {
+        "dishName": "Green Onion Pancake",
+        "price": 4.99,
+        "image": "https://www.thelittleepicurean.com/wp-content/uploads/2018/02/green-onion-pancakes-3.jpg"
       }
     ],
-    "image": "https://lookaside.fbsbx.com/lookaside/crawler/media/?media_id=100035434644148",
+    "image": "https://d3n32ilufxuvd1.cloudfront.net/6183ae4531f10a00490028ef/3209825/screenshot-901a45ce-d93c-4708-a4da-b3d8ca1aeeba_readyscr_1024.jpg",
+    "storeId": 13
+  },
+  {
+    "cityName": "Los Angeles",
+    "storeName": "El Patio",
+    "category": "Mexican",
+    "products": [
+      {
+        "dishName": "Cumin-Crusted Pork Chops with Grilled Corn and Avocado Salsa",
+        "price": 22.99,
+        "image": "https://i.pinimg.com/736x/3f/96/0e/3f960e8ac4fea819a1d5032a9fbcc8d3.jpg"
+      },
+      {
+        "dishName": "Carne Asada Tacos with Fresh Cilantro and Onion",
+        "price": 15.95,
+        "image": "http://www.latortillafactory.com/wp-content/uploads/2016/03/StreetTacos_6.jpg"
+      },
+      {
+        "dishName": "Chicken Fajitas with Sauteed Onions and Bell Peppers",
+        "price": 18.5,
+        "image": "https://easyweeknightrecipes.com/wp-content/uploads/2021/07/grilled-chicken-fajitas-6.jpg"
+      },
+      {
+        "dishName": "Chiles Rellenos with Roasted Poblano Peppers and Queso Fresco",
+        "price": 19.95,
+        "image": "https://therecipecritic.com/wp-content/uploads/2023/04/chili-relleno-2-667x1000.jpg"
+      },
+      {
+        "dishName": "Taco Salad with Ground Beef, Lettuce, Tomato, and Sour Cream",
+        "price": 13.5,
+        "image": "https://thecozycook.com/wp-content/uploads/2022/01/Taco-Salad-Recipe-500x551.jpg"
+      },
+      {
+        "dishName": "Grilled Skirt Steak with Chimichurri Sauce and Saffron Rice",
+        "price": 29.99,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2016/08/Skirt-Steak-with-Chimichurri-Sauce_4.jpg"
+      }
+    ],
+    "image": "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/53e0da73759469.5c13cc14d4f2b.png",
+    "storeId": 14
+  },
+  {
+    "cityName": "Portland",
+    "storeName": "Wildfire Grill",
+    "category": "Steakhouse & BBQ",
+    "products": [
+      {
+        "dishName": "Goji Berry-glazed Venison Skewers",
+        "price": 24.95,
+        "image": "https://culinary.1touchfood.com/wp-content/uploads/2023/12/Firefly-Game-Meets-Spice-Venison-and-Juniper-Berry-Skewers-Recipe-64752_resize.jpg"
+      },
+      {
+        "dishName": "Cajun Shrimp Boil",
+        "price": 18.95,
+        "image": "https://simpleseafoodrecipes.com/wp-content/uploads/2023/05/shrimp-boil-recipe-8-1-768x1024.jpg"
+      },
+      {
+        "dishName": "Miso Glazed Scallops",
+        "price": 22.95,
+        "image": "https://images.media-allrecipes.com/userphotos/960x960/3755802.jpg"
+      },
+      {
+        "dishName": "Korean BBQ Pork Ribs",
+        "price": 21.95,
+        "image": "https://glebekitchen.com/wp-content/uploads/2018/04/koreanbraisedporkribsfront.jpg"
+      },
+      {
+        "dishName": "Roasted Vegetable Skewers",
+        "price": 14.95,
+        "image": "https://i.ytimg.com/vi/-p75HPXr_u4/maxresdefault.jpg"
+      },
+      {
+        "dishName": "Grilled Lamb Chops with Chimichurri",
+        "price": 25.95,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2020/06/Grilled-Lamb-Chops-with-Mint-Chimichurri-3-768x1152.jpg"
+      }
+    ],
+    "image": "https://images.sirved.com/ChIJkWCYg-jV3IkR0AWUb8hWzMc/6w7S7fSKJl.png",
+    "storeId": 15
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Bella Vita Ristorante",
+    "category": "Italian Desserts",
+    "products": [
+      {
+        "dishName": "Tiramisù",
+        "price": 6.95,
+        "image": "https://littlesunnykitchen.com/wp-content/uploads/2021/01/Easy-Tiramisu-Recipe-2.jpg"
+      },
+      {
+        "dishName": "Panna Cotta con Frutta",
+        "price": 7.25,
+        "image": "https://i.pinimg.com/originals/64/52/5b/64525b2172d3db59014e17643326fe73.png"
+      },
+      {
+        "dishName": "Gelato alla Vaniglia",
+        "price": 4.5,
+        "image": "https://static.agrodolce.it/app/uploads/2017/06/gelato-vaniglia.jpg"
+      },
+      {
+        "dishName": "Cannoli Siciliani",
+        "price": 5.75,
+        "image": "https://cdn.ilclubdellericette.it/wp-content/uploads/2017/07/cannoli-siciliani.jpg"
+      },
+      {
+        "dishName": "Sfogliatelle con Ricotta",
+        "price": 6.25,
+        "image": "http://2.bp.blogspot.com/-Uxv6yFq3q0I/U4kmQ2rUT-I/AAAAAAAAAwU/2-MiLHgcPVY/s1600/Sfogliatelle.jpg"
+      }
+    ],
+    "image": "https://static.spotapps.co/web/bellavitasedona--com/custom/logo.png",
+    "storeId": 16
+  },
+  {
+    "cityName": "Miami",
+    "storeName": "Tropical Bites",
+    "category": "American (New)",
+    "products": [
+      {
+        "dishName": "Guava-infused Turkey Roast",
+        "price": 19.95,
+        "image": "https://2.bp.blogspot.com/-2OndrxqyRbQ/WDtOziBtP_I/AAAAAAAAJEw/oCgIzKZ0_Aoa9b3g5NGZZ-xdauKMXBReQCLcB/s1600/DSC_0479.JPG"
+      },
+      {
+        "dishName": "Grilled Steak Fajitas",
+        "price": 17.99,
+        "image": "http://irepo.primecp.com/2020/05/450403/Grilled-Steak-Fajitas_UserCommentImage_ID-3736364.jpg?v=3736364"
+      },
+      {
+        "dishName": "Pan-seared Salmon with Mango Salsa",
+        "price": 24.99,
+        "image": "https://i.redd.it/tl79u717fk471.jpg"
+      },
+      {
+        "dishName": "Veggie Burger with Sweet Potato Fries",
+        "price": 12.95,
+        "image": "https://burgerrecipes.info/wp-content/uploads/2023/02/Hearty-Veggie-Burger-With-Sweet-Potato-Fries.png"
+      },
+      {
+        "dishName": "Crab Cakes with Remoulade Sauce",
+        "price": 21.49,
+        "image": "https://www.cookedbyjulie.com/wp-content/uploads/2021/03/crab-cakes-one.jpg"
+      },
+      {
+        "dishName": "Spicy Shrimp Tacos",
+        "price": 18.99,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2021/07/Spicy-Shrimp-Tacos-4-1-scaled.jpg"
+      },
+      {
+        "dishName": "Crispy Chicken Sandwich with Avocado Coleslaw",
+        "price": 14.95,
+        "image": "https://i1.wp.com/thefoodybean.com/wp-content/uploads/2022/03/img_6723-scaled.jpg?strip=info&w=1967&ssl=1"
+      }
+    ],
+    "image": "http://tropicalbites.menu/wp-content/uploads/2018/06/Tropical-Bites-logo-large.png",
+    "storeId": 17
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Bistro Bliss",
+    "category": "Seafood",
+    "products": [
+      {
+        "dishName": "Grilled Steak Frites",
+        "price": 22.99,
+        "image": "https://images.themodernproper.com/billowy-turkey/production/posts/2022/SteakFrites_14.jpg?w=1200&h=1800&fm=jpg&auto=compress&fit=crop&dm=1662581758&s=93440b0e337310e7397388a154ac9f00"
+      },
+      {
+        "dishName": "Pan-Seared Chicken Breast",
+        "price": 18.95,
+        "image": "https://whatsinthepan.com/wp-content/uploads/2017/12/Easy-Pan-Seared-Chicken.jpg"
+      },
+      {
+        "dishName": "Orange Zest-rubbed Salmon Salad",
+        "price": 19.5,
+        "image": "https://www.olivado.com/wp-content/uploads/2020/02/salmon-sashimi-soy-orange-salad-2000x2000.jpg"
+      },
+      {
+        "dishName": "Lobster Bisque",
+        "price": 14.99,
+        "image": "http://www.howsweeteats.com/wp-content/uploads/2018/11/lobster-bisque-I-howsweeteats.com-6.jpg"
+      },
+      {
+        "dishName": "Seared Scallops with Garlic Shrimp",
+        "price": 28.95,
+        "image": "https://i.pinimg.com/originals/0c/b8/5e/0cb85e79452b95b020400d2bd49fa2fe.jpg"
+      },
+      {
+        "dishName": "Shrimp and Vegetable Stir Fry",
+        "price": 16.5,
+        "image": "http://www.dinneratthezoo.com/wp-content/uploads/2016/09/teriyaki-shrimp-stir-fry-683x1024.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=ANhwFev6Qm3qU95Ptp69Eoe&oh=00_AYBaLYC7n80Zs0MgsxxmSs2XZV--Mv5Bpwvp_JIVvKSMhw&oe=675D1821",
+    "storeId": 18
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Sushi Palace",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Salmon Nigiri",
+        "price": 8.99,
+        "image": "https://izzycooking.com/wp-content/uploads/2020/10/Salmon-Nigiri-1-683x1024.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Roll",
+        "price": 10.99,
+        "image": "https://thewoodenskillet.com/wp-content/uploads/2023/06/spicy-tuna-roll-recipe-2.jpg"
+      },
+      {
+        "dishName": "Tempura Shrimp",
+        "price": 12.99,
+        "image": "https://simplyhomecooked.com/wp-content/uploads/2019/12/shrimp-tempura-recipe-8.jpg"
+      },
+      {
+        "dishName": "Miso Soup",
+        "price": 3.99,
+        "image": "https://www.thespruceeats.com/thmb/q5pzZZKO021eP9s4x_-Mq6m_I8Q=/4494x3000/filters:fill(auto,1)/basic-miso-soup-3377886_09-5b3f7fb6c9e77c00378bf68f.jpg"
+      },
+      {
+        "dishName": "Green Tea Ice Cream",
+        "price": 5.99,
+        "image": "https://gourmetmami.com/wp-content/uploads/2021/02/matcha-ice-cream-768x840.jpg"
+      },
+      {
+        "dishName": "California Roll",
+        "price": 9.99,
+        "image": "https://www.simplyrecipes.com/thmb/RO934yz6fcEFphwCIJyaQWt9siI=/3843x2562/filters:no_upscale():max_bytes(150000):strip_icc()/Simply-Recipes-California-Roll-LEAD-05-3c3a2fb4a9034e5c8cb34d6a24d9731e.jpg"
+      }
+    ],
+    "image": "https://static.takeaway.com/images/restaurants/ch/O0O5P7R1/logo_465x320.png",
+    "storeId": 19
+  },
+  {
+    "cityName": "Berlin",
+    "storeName": "Bratwurst Haus",
+    "category": "German",
+    "products": [
+      {
+        "dishName": "Sour Duck With Red Cabbage",
+        "price": 19.95,
+        "image": "https://production-media.gousto.co.uk/cms/mood-image/1448---Duck-Breast-Braised-Red-Cabbage-Potato--Parsnip-Gratin.jpg"
+      },
+      {
+        "dishName": "Spätzle mit Käse und Zwiebeln",
+        "price": 14.5,
+        "image": "https://www.mein-schoener-garten.de/sites/default/files/styles/og_image/public/2022-01/kasespatzle-mit-zwiebeln-msl.jpg?h=c3bf4dd4&itok=XzYJe-3v"
+      },
+      {
+        "dishName": "Currywurst mit Pommes Frites",
+        "price": 10.75,
+        "image": "https://image.brigitte.de/11724870/t/_Z/v3/w1440/r1/-/pommes-frites-mit-currywurst.jpg"
+      },
+      {
+        "dishName": "Schweinshaxe mit Kartoffeln und Salat",
+        "price": 22,
+        "image": "https://images.services.kitchenstories.io/O19YVUMxo0fZkJ04bVyz2nU82m8=/3840x0/filters:quality(85)/images.kitchenstories.io/recipeImages/R872-photo-final-4x3.jpg"
+      },
+      {
+        "dishName": "Apfelstrudel mit Vanilleeis",
+        "price": 8.95,
+        "image": "https://www.cooknsoul.de/wp-content/uploads/2020/11/Apfelstrudel-mit-Vanilleeis-1200x800.jpg"
+      },
+      {
+        "dishName": "Grünkohl mit Wurst und Kartoffeln",
+        "price": 16.25,
+        "image": "https://www.justspices.de/media/recipe/Kohl_Allrounder_Gruenkohl_mit_Kartoffeln_und_Mettenden-3.jpg"
+      }
+    ],
+    "image": "https://www.bratwursthaus.com/cms/uploads/header/logo.png",
+    "storeId": 20
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Taste of Asia",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Custard Apple Tart",
+        "price": 12.99,
+        "image": "https://siftrva.com/wp-content/uploads/2023/09/diff-1024x1536.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Scallops with Daikon Slaw",
+        "price": 25.95,
+        "image": "https://i.pinimg.com/originals/a7/a5/af/a7a5af06b5bd4e68078ca9c9df696769.jpg"
+      },
+      {
+        "dishName": "Lychee and Mint Sorbet",
+        "price": 6.5,
+        "image": "https://whisk-res.cloudinary.com/image/upload/g_auto,g_auto,c_fill,q_60,f_auto,h_600,w_800/v1596631504/recipe/e4d2b43cbbc54f363a7e9003c329c446.jpg"
+      },
+      {
+        "dishName": "Sesame Crusted Salmon with Stir-Fried Vegetables",
+        "price": 22,
+        "image": "http://assets.epicurious.com/photos/54aca76b19925f464b3ae3c0/master/pass/51217620_sesame-crusted-salmon_1x1.jpg"
+      },
+      {
+        "dishName": "Coconut Rice Pudding with Fresh Fruit",
+        "price": 8.25,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/Coconut-Rice-Pudding_EXPS_FT21_27678_F_0923_1-7.jpg?fit=700%2C1024"
+      },
+      {
+        "dishName": "Spicy Beef and Broccoli Stir Fry",
+        "price": 18.5,
+        "image": "https://bluejeanchef.com/uploads/2021/09/Beef-and-Broccoli-Stirfry-1280-4409.jpg"
+      }
+    ],
+    "image": "https://menufyproduction.imgix.net/637342404642590436+267619.png?auto=compress,format&fit=max&w=1024&h=1024",
+    "storeId": 21
+  },
+  {
+    "cityName": "Austin",
+    "storeName": "Bubba's BBQ Shack",
+    "category": "Barbecue",
+    "products": [
+      {
+        "dishName": "St. Louis Pork Ribs",
+        "price": 18.99,
+        "image": "http://cdn.shopify.com/s/files/1/2530/7762/products/st-louis-ribs-0010.jpg?v=1628183588"
+      },
+      {
+        "dishName": "Cajun Pulled Pork Sandwich",
+        "price": 14.99,
+        "image": "https://www.yummly.com/images/Cheesy-Maple-Bacon-Cajun-Pulled-Pork-Sandwich-recipe-1597238"
+      },
+      {
+        "dishName": "Burnt Ends Nachos",
+        "price": 12.99,
+        "image": "https://www.tostitos.com/sites/tostitos.com/files/2021-11/recipe-KC_chiefs.jpg"
+      },
+      {
+        "dishName": "Mac 'n Cheese",
+        "price": 6.99,
+        "image": "https://www.thespruceeats.com/thmb/HP8-i7Gqx39wGB1fANmIirH6_og=/6048x4032/filters:fill(auto,1)/baked-macaroni-and-cheese-183780212-5892ac5b3df78caebcfa3bc9.jpg"
+      },
+      {
+        "dishName": "Sweet Potato Fries",
+        "price": 4.99,
+        "image": "https://www.wellplated.com/wp-content/uploads/2020/08/Baked-Sweet-Potato-Fries.jpg"
+      }
+    ],
+    "image": "https://i.etsystatic.com/10839180/r/il/83e0ac/1260703113/il_1140xN.1260703113_4qzx.jpg",
+    "storeId": 22
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Bao Down",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Pork Belly Buns",
+        "price": 10.99,
+        "image": "http://culinessa.com/wp-content/uploads/2014/04/IMG_4984.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken Wings",
+        "price": 14.99,
+        "image": "https://www.chilesandsmoke.com/wp-content/uploads/2022/05/Kung-Pao-Wings_OTFC_Featured.jpg"
+      },
+      {
+        "dishName": "Braised Short Ribs",
+        "price": 19.99,
+        "image": "https://www.closetcooking.com/wp-content/uploads/2020/03/French-Braised-Short-Ribs-1200-9393.jpg"
+      },
+      {
+        "dishName": "Spicy Edamame Dumplings",
+        "price": 8.99,
+        "image": "https://i.pinimg.com/originals/b8/af/f6/b8aff66fd4cd8e225d741f3011ef71c0.jpg"
+      },
+      {
+        "dishName": "Sweet Potato Gyoza",
+        "price": 7.99,
+        "image": "https://images.squarespace-cdn.com/content/v1/60b8ecdbc6320a77cc49047e/1678707013775-ONHS6E8CWLYQQ13Q29C5/2015-yd-sweet-potato-gyoza-recipe-2_orig.jpg"
+      },
+      {
+        "dishName": "Miso Glazed Salmon",
+        "price": 16.99,
+        "image": "https://tiffycooks.com/wp-content/uploads/2022/10/8DD66941-6C69-4DA5-9362-B51B7AAD0616-scaled.jpg"
+      },
+      {
+        "dishName": "Kimchi Fried Rice",
+        "price": 12.99,
+        "image": "https://assets.rebelmouse.io/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbWFnZSI6Imh0dHBzOi8vcmFzYW1hbGF5c2lhLmNvbS93cC1jb250ZW50L3VwbG9hZHMvMjAxMS8wNi9raW1jaGktZnJpZWQtcmljZS5qcGciLCJleHBpcmVzX2F0IjoxNjQxNjMxMzQyfQ.g07qWxg7IItIQFhOoVautEmsmxE_kxC3QdBWvBDaO-o/img.jpg?width=2000&height=2000"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/5b/c8/fd/5bc8fdfea29f38b9e08463df443a2a12.jpg",
+    "storeId": 23
+  },
+  {
+    "cityName": "Lima",
+    "storeName": "El Olivo",
+    "category": "Latin American",
+    "products": [
+      {
+        "dishName": "Quail With Lime Sauce",
+        "price": 23.99,
+        "image": "https://thumbs.dreamstime.com/z/baked-quail-sauces-lime-beer-wooden-board-baked-quail-lemon-beer-166560124.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken with Chimichurri",
+        "price": 16.95,
+        "image": "https://www.ourhappymess.com/wp-content/uploads/2020/07/Grilled-Chimichurri-Chicken-6.jpg"
+      },
+      {
+        "dishName": "Ceviche Mixto",
+        "price": 14.99,
+        "image": "http://upload.wikimedia.org/wikipedia/commons/c/c1/Ceviche_mixto_890.JPG"
+      },
+      {
+        "dishName": "Churrasco de Puerco con Papas Arrugadas",
+        "price": 18.95,
+        "image": "https://img-global.cpcdn.com/recipes/0a2020a9832f21d5/680x482cq70/churrasco-de-cerdo-con-papas-foto-principal.jpg"
+      },
+      {
+        "dishName": "Arroz con Mariscos",
+        "price": 19.95,
+        "image": "https://www.eatperu.com/wp-content/uploads/2020/12/close-up-of-rice-paella-dish-from-peru.jpeg"
+      },
+      {
+        "dishName": "Sopa de Lentejas",
+        "price": 8.99,
+        "image": "https://inmamamaggieskitchen.com/wp-content/uploads/2021/03/Sopa-de-Lentejas-2.jpg"
+      }
+    ],
+    "image": "https://image.freepik.com/vector-gratis/aceite-oliva-virgen-extra-emblema-rama-olivo-elemento-logotipo-etiqueta-emblema-signo-ilustracion_124137-856.jpg",
+    "storeId": 24
+  },
+  {
+    "cityName": "Springfield",
+    "storeName": "Lard Lad's Bake Shoppe",
+    "category": "Desserts",
+    "products": [
+      {
+        "dishName": "Strawberry Shortcake",
+        "price": 6.99,
+        "image": "https://sammyapproves.com/wp-content/uploads/2020/06/107-min.jpg"
+      },
+      {
+        "dishName": "Chocolate Mousse",
+        "price": 8.49,
+        "image": "https://assets.epicurious.com/photos/623a31d6c9c7eabd6dfbb66a/1:1/w_2560%2Cc_limit/Chocolate-Mousse_RECIPE_031722_29918.jpg"
+      },
+      {
+        "dishName": "Pomegranate Pie",
+        "price": 9.99,
+        "image": "https://www.sidechef.com/recipe/acc03bf5-576e-4006-b285-6d459d95ee95.jpg?d=1408x1120"
+      },
+      {
+        "dishName": "Lemon Bars",
+        "price": 7.29,
+        "image": "https://thenovicechefblog.com/wp-content/uploads/2020/02/Lemon-Bar-Recipe.jpg"
+      },
+      {
+        "dishName": "Cheesecake",
+        "price": 10.49,
+        "image": "https://dish.co.nz/assets/media/images/baked-raspberry-cheesecake-dish-80__FillWzg1MCwxMTc0XQ.jpg"
+      },
+      {
+        "dishName": "Apple Crisp",
+        "price": 8.99,
+        "image": "https://life-in-the-lofthouse.com/wp-content/uploads/2021/11/Deep-Dish-Apple-Crisp46.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/736x/5a/5c/ba/5a5cba8e6e0403fe5120a0f7b0408b7f.jpg",
     "storeId": 25
+  },
+  {
+    "cityName": "Honolulu",
+    "storeName": "Ocean Breeze Poke Co.",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Spicy Tuna Poké Bowl",
+        "price": 12.99,
+        "image": "https://tastythriftytimely.com/wp-content/uploads/2023/01/Spicy-Tuna-Watermelon-Poke-Bowl-Featured.jpg"
+      },
+      {
+        "dishName": "Classic Salmon Sashimi",
+        "price": 14.95,
+        "image": "http://static1.squarespace.com/static/5d88ca022c11de1fd1d94810/5d9e544533030a5479c196ef/62164fb20d57842904da0e82/1652904632527/Sashimi+5.jpg?format=1500w"
+      },
+      {
+        "dishName": "Shoyu Chicken Poké Bowl",
+        "price": 11.99,
+        "image": "https://www.foodiecrush.com/wp-content/uploads/2023/05/Poke-Bowl-foodiecrush.com-5.jpg"
+      },
+      {
+        "dishName": "Katsu Tofu Bites",
+        "price": 8.99,
+        "image": "https://woonheng.com/wp-content/uploads/2021/03/Tofu-Katsu-Japanese-Curry-6-1638x2048.jpg"
+      },
+      {
+        "dishName": "Tropical Shrimp Salad",
+        "price": 13.95,
+        "image": "https://www.lifesatomato.com/wp-content/uploads/2022/08/Tropical-Shrimp-Salad-768x596.jpg"
+      },
+      {
+        "dishName": "Avocado Maki Rolls",
+        "price": 10.5,
+        "image": "https://www.myplantifulcooking.com/wp-content/uploads/2023/05/avocado-maki-featured-1024x1024.jpg"
+      }
+    ],
+    "image": "https://www.prosportstickers.com/wp-content/uploads/nc/o/ocean_breeze_waterpark_resort_logo__84745-700x469.jpg",
+    "storeId": 26
+  },
+  {
+    "cityName": "New York",
+    "storeName": "La Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 14.95,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 13.5,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Pasta e Fagioli (Beans)",
+        "price": 12.75,
+        "image": "https://anitalianinmykitchen.com/wp-content/uploads/2018/01/pasta-beans-sq-1-of-1.jpg"
+      },
+      {
+        "dishName": "Rigatoni alla Vodka",
+        "price": 15.25,
+        "image": "https://i.pinimg.com/originals/8d/95/0a/8d950aad32d6ead88ed85e042f3998df.jpg"
+      },
+      {
+        "dishName": "Tortellini en Brodo",
+        "price": 14.5,
+        "image": "https://www.platingsandpairings.com/wp-content/uploads/2022/12/tortellini-en-brodo-recipe-11-1365x2048.jpg"
+      },
+      {
+        "dishName": "Linguine con Clams",
+        "price": 17.95,
+        "image": "https://www.onceuponachef.com/images/2019/03/Linguini-with-Clams-1200x1500.jpg"
+      },
+      {
+        "dishName": "Gnocchi alla Romana",
+        "price": 16.75,
+        "image": "https://i0.wp.com/marisasitaliankitchen.com/wp-content/uploads/2017/05/baked-gnocchi-alla-romana.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 27
+  },
+  {
+    "cityName": "Paris",
+    "storeName": "Le Bistro Moderne",
+    "category": "Fast Food",
+    "products": [
+      {
+        "dishName": "French Fries",
+        "price": 4.5,
+        "image": "https://www.momontimeout.com/wp-content/uploads/2021/05/oven-fries-square.jpeg"
+      },
+      {
+        "dishName": "Sausage Roll",
+        "price": 2.75,
+        "image": "https://www.thespruceeats.com/thmb/u88vcmX48O9jNzdvVttPkwcdpio=/2119x1414/filters:fill(auto,1)/sausage-roll-901ecec7f1d54c10940c1bdbbc1b8e46.jpg"
+      },
+      {
+        "dishName": "Cheese Burger",
+        "price": 6.95,
+        "image": "https://foodetccooks.com/wp-content/uploads/2017/02/IMG_7933.jpg"
+      },
+      {
+        "dishName": "Chicken Nuggets (5pcs)",
+        "price": 8.2,
+        "image": "https://spicybites.co.nz/wp-content/uploads/2023/12/Chicken-Nuggets-2.jpg"
+      },
+      {
+        "dishName": "Grilled Sausage Sandwich",
+        "price": 7.4,
+        "image": "https://images.squarespace-cdn.com/content/v1/545d7c61e4b073a05b4addc7/1587697560864-MQCMN4JVMRXFCNYA8ZB0/ke17ZwdGBToddI8pDm48kPhE_b-FKx_EcxRx4teFEVN7gQa3H78H3Y0txjaiv_0fDoOvxcdMmMKkDsyUqMSsMWxHk725yiiHCCLfrh8O1z4YTzHvnKhyp6Da-NYroOW3ZGjoBKy3azqku80C789l0k5fwC0WRNFJBIXiBeNI5fL8LmMajxsBXeYxVzkYts3ds68Ud4HgM4ArFxmxGpI5hQ/Sausage+Sandwich_h.jpeg"
+      },
+      {
+        "dishName": "Fries With Chili Con Carne",
+        "price": 5.15,
+        "image": "https://sahomeowner.co.za/wp-content/uploads/2015/06/Image-4.jpg"
+      }
+    ],
+    "image": "https://thumbs.dreamstime.com/z/bistro-cafe-vector-logo-badge-hand-written-modern-calligraphy-elegant-lettering-logotype-vintage-retro-style-bistro-cafe-131596264.jpg",
+    "storeId": 28
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Caprese Salad",
+        "price": 12.99,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 14.95,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 8.5,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 16.99,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4.jpg"
+      },
+      {
+        "dishName": "Eggplant Parmesan",
+        "price": 17.95,
+        "image": "https://cdn.apartmenttherapy.info/image/fetch/f_auto,q_auto:eco/https://storage.googleapis.com/gen-atmedia/3/2018/08/c024bcfedd6354f883f878c103ce47b51e919697.jpeg"
+      },
+      {
+        "dishName": "Garlic Shrimp",
+        "price": 18.5,
+        "image": "https://cafedelites.com/wp-content/uploads/2018/06/Creamy-Garlic-Shrimp-IMAGE-68.jpg"
+      },
+      {
+        "dishName": "Ravioli alla Vodka",
+        "price": 15.99,
+        "image": "https://cookingwithcocktailrings.com/wp-content/uploads/2021/02/LobsterRavioliwithBertolliVodkaSauce-59-1-1536x1024.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 29
+  },
+  {
+    "cityName": "London",
+    "storeName": "The Colonial Kitchen",
+    "category": "British - Indian Cuisine",
+    "products": [
+      {
+        "dishName": "Bitter Anglo-Indian Stew",
+        "price": 12.5,
+        "image": "https://media-cdn2.greatbritishchefs.com/media/4vredru2/img81504.whqc_735x1102q80.jpg"
+      },
+      {
+        "dishName": "Shepherd's Pie with a Twist",
+        "price": 14.99,
+        "image": "https://www.gourmetrecipes.org/wp-content/uploads/2023/08/shepherds-pie.png"
+      },
+      {
+        "dishName": "Chicken Tikka Masala Burger",
+        "price": 10.95,
+        "image": "https://nomtasticfoods.net/wp-content/uploads/2020/09/chicken-tikka-masala-burger-2048x1663.jpg"
+      },
+      {
+        "dishName": "Fish & Chips Curry",
+        "price": 13.25,
+        "image": "https://preview.redd.it/xt51dnkaj0b91.jpg?width=1080&crop=smart&auto=webp&s=5c2bfcb3053664b5797a2401be0e6a1f5d87794e"
+      },
+      {
+        "dishName": "Samosa Chaat",
+        "price": 9.99,
+        "image": "https://recipes.timesofindia.com/photo/70551805.cms"
+      },
+      {
+        "dishName": "Ginger Beer Braised Short Ribs",
+        "price": 16.5,
+        "image": "https://www.thefoodjoy.com/wp-content/uploads/2018/07/Ginger-Beer-Braised-Short-Ribs-.jpg"
+      }
+    ],
+    "image": "https://www.colonialkitchenpizza.com/img/logo.gif",
+    "storeId": 30
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Taste of India Bistro",
+    "category": "Indian & Asian Fusion",
+    "products": [
+      {
+        "dishName": "Chicken Tikka Masala Wrap",
+        "price": 12.99,
+        "image": "https://images.squarespace-cdn.com/content/v1/5ccc9bada9ab950174f0b374/1623252160842-3TN13AHCAD16NRYSFR4D/NO_Prototype2_MasalaWrap_Wood_Stack_02+1.jpg"
+      },
+      {
+        "dishName": "Tikka Masala-rubbed Chicken Salad",
+        "price": 14.95,
+        "image": "https://kitchenmai.com/wp-content/uploads/2019/02/IMG_4327.jpg"
+      },
+      {
+        "dishName": "Spiced Shrimp Biryani",
+        "price": 16.5,
+        "image": "https://ministryofcurry.com/wp-content/uploads/2017/06/shrimp-biryani-1-2-3-850x1275.jpg"
+      },
+      {
+        "dishName": "Palak Paneer and Naan Bread Basket",
+        "price": 13.25,
+        "image": "https://fluxfoodie.com/wp-content/uploads/2020/06/IMG_3832-1200x1200.jpeg"
+      },
+      {
+        "dishName": "Baingan Bharta with Basmati Rice",
+        "price": 11.75,
+        "image": "https://www.thecuriouschickpea.com/wp-content/uploads/2020/06/baingan-bharta-9.jpg"
+      },
+      {
+        "dishName": "Mango Lassi Smoothie",
+        "price": 6.99,
+        "image": "https://therecipecritic.com/wp-content/uploads/2023/01/mangolassi-750x1000.jpg"
+      }
+    ],
+    "image": "https://dcassetcdn.com/design_img/272773/35095/35095_2554532_272773_image.jpg",
+    "storeId": 31
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Green Bites Cafe",
+    "category": "Salad Bar",
+    "products": [
+      {
+        "dishName": "Lettuce and Tomato Salad",
+        "price": 8.99,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2018/09/1435032266_1.jpg"
+      },
+      {
+        "dishName": "Greek Salad",
+        "price": 10.49,
+        "image": "https://www.thechunkychef.com/wp-content/uploads/2021/07/Greek-Salad-Recipe-recipe-card.jpg"
+      },
+      {
+        "dishName": "Spinach Salad with Bacon",
+        "price": 9.99,
+        "image": "https://www.thecookierookie.com/wp-content/uploads/2020/06/spinach-salad-spinach-salad-dressing-1-of-6.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 11.99,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Wedge Salad with Chicken",
+        "price": 14.49,
+        "image": "https://theadventurebite.com/wp-content/uploads/2019/05/wedge-salad-recipe_-8-2048x2048.jpg"
+      },
+      {
+        "dishName": "House Salad with Turkey",
+        "price": 12.99,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/BLT-Turkey-Salad_EXPS_OPBZ18_39131_B06_07_6b.jpg"
+      },
+      {
+        "dishName": "Roasted Beet Salad",
+        "price": 13.99,
+        "image": "https://www.walderwellness.com/wp-content/uploads/2019/09/Balsamic-Roasted-Beets-With-Goat-Cheese-Walnuts-Walder-Wellness-4.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/310339091_108701975344581_737148941605230472_n.jpg?_nc_cat=111&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=Lm5WBu-jIHgQ7kNvgGENwBX&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=AcQlWOu73NPNjTO1shoe_Ek&oh=00_AYDrKwzCV0_f5VIuv_fvS7a6m6LUnDYjSqpcUZC7KR9r1w&oe=675D3EC5",
+    "storeId": 32
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Pizzeria Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Margherita Extravirgin",
+        "price": 14.99,
+        "image": "https://c8.alamy.com/comp/2M6AKXE/margherita-pizza-neapolitan-pizza-made-with-san-marzano-tomatoes-mozzarella-cheese-fresh-basil-salt-and-extra-virgin-olive-oil-2M6AKXE.jpg"
+      },
+      {
+        "dishName": "Quattro Formaggi",
+        "price": 16.95,
+        "image": "https://img.freepik.com/premium-photo/quattro-formaggi-pizza-served-dish-top-view-dark-wooden-background_689047-1964.jpg?w=2000"
+      },
+      {
+        "dishName": "Meat Lover's",
+        "price": 18.49,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/Meat-Lover-s-Pizza-Hot-Dish_exps152539_SD143203B10_24_6bC_RMS-5.jpg"
+      },
+      {
+        "dishName": "Vegetarian Delight",
+        "price": 15.99,
+        "image": "https://i1.wp.com/lovethesecretingredient.net/wp-content/uploads/2014/02/Vegetarian-Delight-Roasted-veggies-from-Jan-28-2014.jpeg"
+      },
+      {
+        "dishName": "Sicilian Style",
+        "price": 20.95,
+        "image": "https://www.homemadeitaliancooking.com/wp-content/uploads/2016/01/Bowl-Eggplant-pasta-2.jpg"
+      },
+      {
+        "dishName": "Anchovies & Artichokes",
+        "price": 17.49,
+        "image": "https://cookingtoentertain.com/wp-content/uploads/2019/11/Artichokes-with-anchovies-768x1024.webp"
+      }
+    ],
+    "image": "https://static.lieferando.de/images/restaurants/de/3OQ1PQ7N/logo_465x320.png",
+    "storeId": 33
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Green Earth Cafe",
+    "category": "Soups and Salads",
+    "products": [
+      {
+        "dishName": "Vegetable Soup",
+        "price": 8.99,
+        "image": "http://kendrastreats.com/wp-content/uploads/2016/09/IMG_3213.jpg"
+      },
+      {
+        "dishName": "Tom Yum Soup",
+        "price": 10.99,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2019/09/Tom-Yum-creamy-version_6.jpg"
+      },
+      {
+        "dishName": "Lentil Curry",
+        "price": 9.49,
+        "image": "https://pescetarian.kitchen/wp-content/uploads/2017/02/Red-lentil-curry-4.jpg"
+      },
+      {
+        "dishName": "Spicy Butternut Squash",
+        "price": 11.99,
+        "image": "https://reciperunner.com/wp-content/uploads/2021/01/sweet-spicy-roasted-butternut-squash-photos-1490x2048.jpg"
+      },
+      {
+        "dishName": "French Onion Soup",
+        "price": 12.99,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2021/12/Classic-French-Onion-Soup-2-scaled.jpg"
+      }
+    ],
+    "image": "https://lovebedford.co.uk/wp-content/uploads/2022/08/Green-Earth-Cafe-logo-1-1-768x771.jpg",
+    "storeId": 34
+  },
+  {
+    "cityName": "Auckland",
+    "storeName": "Tropical Bites",
+    "category": "Café & Grill",
+    "products": [
+      {
+        "dishName": "Kiwi Fruit-infused Chicken Roast",
+        "price": 19.95,
+        "image": "https://i.pinimg.com/originals/e4/49/be/e449bebfa14850b7541d0e6a872e3505.png"
+      },
+      {
+        "dishName": "Grilled Steak with Garlic Mashed Potatoes",
+        "price": 24.99,
+        "image": "https://rachaelsgoodeats.com/wp-content/uploads/2023/06/IMG_3163-scaled.jpg"
+      },
+      {
+        "dishName": "Pan-seared Salmon with Lemon Butter",
+        "price": 22.5,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2018/05/Pan-Seared-Salmon-with-Lemon-Butter-Sauce-4.jpg"
+      },
+      {
+        "dishName": "Roasted Vegetable Wrap with Hummus",
+        "price": 14.95,
+        "image": "https://brandsitesplatform-res.cloudinary.com/image/fetch/w_1540,c_scale,q_auto:eco,f_auto,fl_lossy,dpr_1.0,e_sharpen:85/https://assets.brandplatform.generalmills.com/-/media/project/gmi/oldelpaso/oldelpaso-au/oepp/recipes/new-images/roasted-vegetable-and-hummus-wraps/roasted-vegetable-and-hummus-wraps-hero.jpg%3Fw%3D800%26rev%3D0c6ac0b3570143d4a7f98731cf977a48%201540w"
+      },
+      {
+        "dishName": "Chicken Caesar Salad with Croutons",
+        "price": 16.99,
+        "image": "http://www.simplesweetsavory.com/wp-content/uploads/2016/04/Chicken-Caesar-Salad-wide.jpg"
+      },
+      {
+        "dishName": "Thai Green Curry with Shrimp and Vegetables",
+        "price": 20,
+        "image": "https://myglobalcuisine.com/wp-content/uploads/2017/10/ServedwithSpoons_DSC_3414.jpg"
+      }
+    ],
+    "image": "http://tropicalbites.menu/wp-content/uploads/2018/06/Tropical-Bites-logo-large.png",
+    "storeId": 35
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Brewster's Bistro",
+    "category": "Fine Dining",
+    "products": [
+      {
+        "dishName": "Milk Chocolate-Crusted Filet Mignon",
+        "price": 45.99,
+        "image": "https://www.wholesomeyum.com/wp-content/uploads/2021/05/wholesomeyum-Perfect-Filet-Mignon-Recipe-21.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Scallops with Milk Chocolate Beurre Blanc",
+        "price": 39.95,
+        "image": "https://i.pinimg.com/originals/8c/83/7f/8c837f4a079fcf42ee98e1bac2ca4c06.jpg"
+      },
+      {
+        "dishName": "Roasted Vegetable Wrap with Caramelized Onions and Milk Chocolate Aioli",
+        "price": 14.99,
+        "image": "https://4.bp.blogspot.com/-KfIOFgmFZ5U/TwOulUrpd3I/AAAAAAAABsI/6b5X0tGybCs/s1600/P1030455.JPG"
+      },
+      {
+        "dishName": "Milk Chocolate-Infused Beef Wellington (10 oz)",
+        "price": 34.95,
+        "image": "https://www.simplyrecipes.com/thmb/Kw8FXpTREEi79MkilHlCvSQ1KxU=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/Simply-Recipes-Beef-Wellington-LEAD-09-680526da84824d9fae5b289c13ac0311.jpg"
+      },
+      {
+        "dishName": "Braised Short Ribs in a Rich Milk Chocolate BBQ Sauce",
+        "price": 29.99,
+        "image": "https://cookwhatyoulove.com/wp-content/uploads/2021/11/short-ribs-finished-6.jpg"
+      },
+      {
+        "dishName": "Crispy Skinned Salmon with Lemon-Garlic Butter and Microgreens (optional: Milk Chocolate Mole)",
+        "price": 32.95,
+        "image": "https://thegourmetcookbook.com/wp-content/uploads/2023/04/Salmon-Lemon-Garlic-Butter-Recipe-1680619244561.jpg"
+      }
+    ],
+    "image": "https://flogginimages.s3.ap-south-1.amazonaws.com/brands/brands_795_1685024664.8235643.png",
+    "storeId": 36
+  },
+  {
+    "cityName": "Florence",
+    "storeName": "Trattoria della Nonna",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Pappardelle Alla Bolognese",
+        "price": 19.95,
+        "image": "https://i2.wp.com/bestrecipesuk.com/wp-content/uploads/2020/01/pappardelle-bolognese.jpg?fit=3024%2C4032&ssl=1"
+      },
+      {
+        "dishName": "Bruschetta with Tomato and Basil",
+        "price": 8.5,
+        "image": "https://www.jessicagavin.com/wp-content/uploads/2020/07/bruschetta-15.jpg"
+      },
+      {
+        "dishName": "Spaghetti Carbonara",
+        "price": 16.95,
+        "image": "https://therecipecritic.com/wp-content/uploads/2018/04/pasta-carbonara-15.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken with Roasted Vegetables",
+        "price": 14,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/exps98665__SD143206C04_03_7b-8.jpg"
+      },
+      {
+        "dishName": "Risotto alla Milanese",
+        "price": 20.5,
+        "image": "https://i.pinimg.com/originals/a1/b9/36/a1b9367f8eb4525534fd8b24b2b70843.jpg"
+      },
+      {
+        "dishName": "Pollo alla Cacciatora",
+        "price": 18.25,
+        "image": "https://assets.rebelmouse.io/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpbWFnZSI6Imh0dHBzOi8vd3d3Lmluc2lkZXRoZXJ1c3RpY2tpdGNoZW4uY29tL3dwLWNvbnRlbnQvdXBsb2Fkcy8yMDIwLzA4L0NoaWNrZW4tY2FjY2lhdG9yZS0xMjAwcHgtSW5zaWRlLXRoZS1SdXN0aWMtS2l0Y2hlbi0xLmpwZyIsImV4cGlyZXNfYXQiOjE2MTE3NjQ1MDF9.zBJwrHGgGkqeLTEPKnLuK7jCDrYbGD8-3jR0Rb02IPQ/img.jpg?width=2000&height=2000"
+      }
+    ],
+    "image": "https://shoppingmalldova.md/wp-content/uploads/2022/09/Trattoria_logo.png",
+    "storeId": 37
+  },
+  {
+    "cityName": "Baku",
+    "storeName": "Siyah",
+    "category": "Cafes & Restaurants",
+    "products": [
+      {
+        "dishName": "Azerbaijani Wheat Soup",
+        "price": 8.95,
+        "image": "https://thumbs.dreamstime.com/b/national-dish-azerbaijan-kyufte-bozbash-serving-pea-soup-large-meatballs-inside-sour-fruits-263542352.jpg"
+      },
+      {
+        "dishName": "Qovurma (Beef Stew)",
+        "price": 12.99,
+        "image": "https://thumbs.dreamstime.com/z/turkish-nar-qovurma-nar-qovurma-turkish-stew-lamb-pomegranate-108239858.jpg"
+      },
+      {
+        "dishName": "Shashlik (Mutton Skewers)",
+        "price": 14.95,
+        "image": "https://thumbs.dreamstime.com/b/mutton-slices-barbecue-skewers-shashlik-marinated-mint-red-wine-homemade-ketchup-fried-aromatic-herbs-served-slate-277349630.jpg"
+      },
+      {
+        "dishName": "Plov (Rice Pilaf with Meat)",
+        "price": 13.49,
+        "image": "https://thumbs.dreamstime.com/z/plate-rice-meat-vegetables-uzbec-plov-pilaf-dish-imaginary-illustration-292062025.jpg"
+      },
+      {
+        "dishName": "Lahmajoun (Azerbaijani-Style Pizza)",
+        "price": 10.99,
+        "image": "https://thearmeniankitchen.com/wp-content/uploads/2009/07/Lahmajoun-1-scaled.jpg"
+      },
+      {
+        "dishName": "Gurzala (Beef and Vegetable Stew)",
+        "price": 11.95,
+        "image": "https://images.media-allrecipes.com/userphotos/8754617.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/29/82/32/298232374796b3edb4c377231b5be920.jpg",
+    "storeId": 38
+  },
+  {
+    "cityName": "Bangkok",
+    "storeName": "Thong Salad Shop",
+    "category": "Thai Restaurant",
+    "products": [
+      {
+        "dishName": "Som Tam (Papaya Salad)",
+        "price": 80,
+        "image": "https://www.thespruceeats.com/thmb/yhRUOatVWMb6Unf4fjSL28IsyAM=/4680x3120/filters:fill(auto,1)/som-tam-thai-green-papaya-salad-3217407-hero-01-9e4281d9e4a64b0e8bb4930debcef3a3.jpg"
+      },
+      {
+        "dishName": "Massaman Curry with Chicken",
+        "price": 100,
+        "image": "https://spicecravings.com/wp-content/uploads/2018/05/Massaman-Curry-1-1.jpg"
+      },
+      {
+        "dishName": "Pad Thai",
+        "price": 90,
+        "image": "https://d3cizcpymoenau.cloudfront.net/images/32489/SFS_pad_thai-44.jpg"
+      },
+      {
+        "dishName": "Tom Yum Soup with Shrimp",
+        "price": 120,
+        "image": "https://i0.wp.com/www.valerieskeepers.com/wp-content/uploads/2014/11/Tom-Yum-Soup_10-1-sur-1.jpg"
+      },
+      {
+        "dishName": "Green Curry with Pork",
+        "price": 110,
+        "image": "https://hungryinthailand.com/wp-content/uploads/2023/06/Thai-green-curry-pork-768x1024.webp"
+      },
+      {
+        "dishName": "Spring Rolls (Vegetable)",
+        "price": 60,
+        "image": "https://www.thespruceeats.com/thmb/w-ypJBh03oC3mLNWpzTUFqQqZns=/4494x3000/filters:no_upscale():max_bytes(150000):strip_icc()/thai-fresh-rolls-with-vegetarian-option-3217706_form-rolls-step-07-f2d1c96942b04dd0830026702e697f17.jpg"
+      },
+      {
+        "dishName": "Spicy Grilled Chicken",
+        "price": 140,
+        "image": "https://littlesunnykitchen.com/wp-content/uploads/2021/07/Grilled-BBQ-Chicken-Recipe-1.jpg"
+      }
+    ],
+    "image": "https://www.muangthongthani.co/wp-content/uploads/2014/10/logo-salad-factory-small.jpg",
+    "storeId": 39
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Pasta With Tomato And Basil",
+        "price": 12.99,
+        "image": "https://lexiscleankitchen.com/wp-content/uploads/2021/07/Fresh-Tomato-Pasta-6.jpg"
+      },
+      {
+        "dishName": "Spaghetti Carbonara",
+        "price": 14.95,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2023/01/Carbonara_6a.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 15.5,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 8.99,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 10.95,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Pizza Margherita",
+        "price": 13.5,
+        "image": "https://cdn.loveandlemons.com/wp-content/uploads/2019/09/margherita-pizza-1080x1080.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 40
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Grill Masters",
+    "category": "American",
+    "products": [
+      {
+        "dishName": "Chicken Steak",
+        "price": 19.99,
+        "image": "https://www.licious.in/blog/wp-content/uploads/2020/12/Chicken-Steak-min-768x768.jpg"
+      },
+      {
+        "dishName": "BBQ Ribs",
+        "price": 16.95,
+        "image": "https://www.barossafinefoods.com.au/glide-cache/containers/main/2020_bff_porkribs_bbq_website-2.jpg/03d880f2ca84b83fdeb147548e7d9b12.jpg"
+      },
+      {
+        "dishName": "Grilled Salmon",
+        "price": 22.5,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2018/05/grilled-salmon-3.jpg"
+      },
+      {
+        "dishName": "Veggie Burger",
+        "price": 14.99,
+        "image": "https://assets.bonappetit.com/photos/57acae2d1b33404414975121/master/pass/ultimate-veggie-burger.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 18.95,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Fried Chicken Wings",
+        "price": 12.95,
+        "image": "https://www.thespruceeats.com/thmb/CWfeSCngoL5zOxlR2tsBWETtZ3U=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/traditional-chicken-wings-912937-hero-01-6c1a003373a54538a732abc0005145d8.jpg"
+      },
+      {
+        "dishName": "Chicken Fajitas",
+        "price": 20.5,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2021/04/Chicken-Fajitas-011-scaled.jpg"
+      }
+    ],
+    "image": "https://grill-masters.netlify.app/images/grill_masters_logo.png",
+    "storeId": 41
+  },
+  {
+    "cityName": "New York",
+    "storeName": "French Bistro",
+    "category": "Desserts & Pies",
+    "products": [
+      {
+        "dishName": "Kiwiberry And Cantaloupe Tart",
+        "price": 14.99,
+        "image": "http://i0.wp.com/globaltableadventure.com/wp-content/uploads/2012/04/monaco.food_.img_5339.jpg"
+      },
+      {
+        "dishName": "Raspberry And Cream Tartelet",
+        "price": 6.99,
+        "image": "https://cdn11.bigcommerce.com/s-vm6doh2w4n/images/stencil/1280x1280/products/8888/21523/wmifbcfaatmwttxjcejo__40282.1697527810.jpg?c=1"
+      },
+      {
+        "dishName": "Chocolate Soufflé",
+        "price": 8.99,
+        "image": "https://springhouseturtle.com/wp-content/uploads/2018/10/chocolate-souffle.jpg"
+      },
+      {
+        "dishName": "Lemon Meringue Pie",
+        "price": 10.99,
+        "image": "http://cdn.taste.com.au/images/recipes/agt/2006/07/1800.jpg"
+      },
+      {
+        "dishName": "Fresh Fruit Tartine",
+        "price": 12.99,
+        "image": "https://www.thespruceeats.com/thmb/aEBv9n8MINfRj1HT00IxsqWcjq4=/5110x3407/filters:fill(auto,1)/vanilla-custard-fruit-tart-recipe-101342-hero-01-d911d9c04f914432bbc4700c3e678b2c.jpg"
+      },
+      {
+        "dishName": "Cinnamon Sugar Donut Holes",
+        "price": 4.99,
+        "image": "https://cravinghomecooked.com/wp-content/uploads/2023/08/cinnamon-sugar-donut-holes-1-18.jpg.webp"
+      }
+    ],
+    "image": "https://logodix.com/logo/1063677.png",
+    "storeId": 42
+  },
+  {
+    "cityName": "Tallinn",
+    "storeName": "Kalev's Kitchen",
+    "category": "Estonian cuisine",
+    "products": [
+      {
+        "dishName": "Rich Estonian Stew",
+        "price": 14.95,
+        "image": "https://c8.alamy.com/comp/R9MA0P/hakkliha-kapsahautis-estonian-cabbage-and-mince-stew-estonian-cuisine-traditional-assorted-dishes-top-view-R9MA0P.jpg"
+      },
+      {
+        "dishName": "Herring Salad",
+        "price": 9.99,
+        "image": "https://www.everyday-delicious.com/wp-content/uploads/2019/12/potato-herring-salad-salatka-sledziowa-z-ziemniakami-everyday-delicious-1.jpg"
+      },
+      {
+        "dishName": "Estonian Meat Pies",
+        "price": 12.5,
+        "image": "https://4.bp.blogspot.com/-e5VOUD0_4N0/WmT80eZdCqI/AAAAAAAACS0/OKeU-0zvO-cAg3IC7CYHJdUNgkWvQMSTgCKgBGAs/s1600/20171224_135832.jpg"
+      },
+      {
+        "dishName": "Kalev's Fried Cakes",
+        "price": 6.95,
+        "image": "https://lh3.googleusercontent.com/bjUSyCDrwj6xm5f2IYNcuRTo2LI3rCLl5aJeexIpfMbrzIh_jiinUqal2uYyyFDQqcSE0RKFQBBEq9QE7b3Alb0UsNTWS4b4-E9luIQ=w900-rj-l85"
+      },
+      {
+        "dishName": "Sour Rye Bread with Cheese",
+        "price": 7.99,
+        "image": "https://www.carolinescooking.com/wp-content/uploads/2018/10/sourdough-rye-bread-picture-cheese.jpg"
+      },
+      {
+        "dishName": "Traditional Estonian Grilled Sausages",
+        "price": 13.95,
+        "image": "https://www.willflyforfood.net/wp-content/uploads/2021/07/estonian-food-verivorst.jpg.webp"
+      }
+    ],
+    "image": "https://baltikum-shop.de/uploads/c/logo-kalev.png",
+    "storeId": 43
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Mango Breeze",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Pan-Seared Salmon with Mango Salsa",
+        "price": 32.95,
+        "image": "https://i.redd.it/tl79u717fk471.jpg"
+      },
+      {
+        "dishName": "Starfruit-glazed Lamb Skewers",
+        "price": 24.5,
+        "image": "http://cdn2.tmbi.com/TOH/Images/Photos/37/1200x1200/Cranberry-Glazed-Lamb-Skewers_exps59569_HC2847498A10_12_5bC_RMS.jpg"
+      },
+      {
+        "dishName": "Spicy Shrimp Stir Fry with Snow Peas",
+        "price": 29.95,
+        "image": "https://littlespicejar.com/wp-content/uploads/2018/08/10-Minute-Shrimp-Snow-Pea-Stir-Fry-5.jpg"
+      },
+      {
+        "dishName": "Vegetable Spring Rolls with Sweet Chili Sauce",
+        "price": 15,
+        "image": "https://img.freepik.com/premium-photo/fried-vegetable-spring-rolls-with-sweet-chili-sauce-wooden-dish-generated-by-ai_1038983-13185.jpg"
+      },
+      {
+        "dishName": "Beef Satay with Peanut Sauce and Cucumber Raita",
+        "price": 26.95,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2021/07/Thai-Beef-Satay-Skewers_24.jpg?resize=80"
+      },
+      {
+        "dishName": "Thai Green Curry with Chicken, Thai Basil, and Jasmine Rice",
+        "price": 28,
+        "image": "https://www.thespruceeats.com/thmb/xVV_Iz_e7RzgKhOhiElYcsNfrV4=/4950x3300/filters:fill(auto,1)/thai-chicken-curry-with-rice-in-a-bowl-154931668-584b54863df78c491e76e74f.jpg"
+      }
+    ],
+    "image": "https://assets.untappd.com/site/beer_logos_hd/beer-5321708_85502_hd.jpeg",
+    "storeId": 44
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 16.99,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 14.99,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 8.99,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Garlic Bread",
+        "price": 6.49,
+        "image": "https://www.ambitiouskitchen.com/wp-content/uploads/2023/02/Garlic-Bread-4.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 10.99,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Eggplant Parmesan",
+        "price": 15.99,
+        "image": "https://cdn.apartmenttherapy.info/image/fetch/f_auto,q_auto:eco/https://storage.googleapis.com/gen-atmedia/3/2018/08/c024bcfedd6354f883f878c103ce47b51e919697.jpeg"
+      },
+      {
+        "dishName": "Ravioli alla Vodka",
+        "price": 18.49,
+        "image": "https://somuchfoodblog.com/wp-content/uploads/2020/04/dc252-rav2-scaled.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 45
+  },
+  {
+    "cityName": "Los Angeles",
+    "storeName": "Taste of China",
+    "category": "Chinese",
+    "products": [
+      {
+        "dishName": "Pork With Pineapple Sauce",
+        "price": 13.99,
+        "image": "https://mommyshomecooking.com/wp-content/uploads/2018/02/Instant-Pot-Hawaiian-Pineapple-Pork-3.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken",
+        "price": 12.99,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2020/02/kung-pao-chicken-1-1024x1536.jpg"
+      },
+      {
+        "dishName": "Egg Foo Young",
+        "price": 10.99,
+        "image": "https://i0.wp.com/athomewithrebecka.com/wp-content/uploads/2017/01/egg-fu-yung-1.jpg"
+      },
+      {
+        "dishName": "Beef with Broccoli",
+        "price": 14.99,
+        "image": "https://kirbiecravings.com/wp-content/uploads/2018/12/beef-broccoli-7.jpg"
+      },
+      {
+        "dishName": "Sweet and Sour Pork",
+        "price": 12.49,
+        "image": "https://bunnyswarmoven.net/wp-content/uploads/2018/02/Pineapplecoffeecake_94.jpg"
+      }
+    ],
+    "image": "https://tastechina.co.uk/wp-content/uploads/sites/42/2017/06/White-Logo-400.png",
+    "storeId": 46
+  },
+  {
+    "cityName": "Portland",
+    "storeName": "Taste of India Bistro",
+    "category": "Indian",
+    "products": [
+      {
+        "dishName": "Sag Paneer",
+        "price": 12.99,
+        "image": "https://www.glutenfreealchemist.com/wp-content/uploads/2020/07/Saag-Paneer-Recipe-a.jpg"
+      },
+      {
+        "dishName": "Chicken Tikka Masala",
+        "price": 14.99,
+        "image": "https://149433378.v2.pressablecdn.com/wp-content/uploads/2020/08/Chicken-Tikka-Masala-scaled.jpg"
+      },
+      {
+        "dishName": "Amchoor-rubbed Chicken Salad",
+        "price": 11.49,
+        "image": "https://www.licious.in/blog/wp-content/uploads/2020/12/3-Step-Chicken-Salad.jpg"
+      },
+      {
+        "dishName": "Palak Paneer",
+        "price": 13.99,
+        "image": "https://healthynibblesandbits.com/wp-content/uploads/2020/01/Saag-Paneer-1.jpg"
+      },
+      {
+        "dishName": "Baingan Bharta",
+        "price": 10.99,
+        "image": "https://www.vegrecipesofindia.com/wp-content/uploads/2021/06/baingan-bharta-1.jpg"
+      },
+      {
+        "dishName": "Gujarati Thali",
+        "price": 16.99,
+        "image": "https://i.pinimg.com/originals/e5/c2/31/e5c231edb9f3595ce1b6ee6868faf25c.jpg"
+      }
+    ],
+    "image": "https://tasteofindiapurdue.com/wp-content/uploads/taste-of-india-logo-solid-1024x275.png",
+    "storeId": 47
+  },
+  {
+    "cityName": "Melbourne",
+    "storeName": "Bistro Bella Vita",
+    "category": "Cafe & Bistro",
+    "products": [
+      {
+        "dishName": "Avocado Toast with Poached Eggs",
+        "price": 19.5,
+        "image": "https://data.thefeedfeed.com/static/2021/04/06/1617726496606c8c20a7a82.jpg"
+      },
+      {
+        "dishName": "Grilled Lamb Chops with Roasted Vegetables",
+        "price": 32,
+        "image": "https://images.eatsmarter.com/sites/default/files/styles/max_size/public/grilled-lamb-chops-with-mixed-vegetables-617894.jpg"
+      },
+      {
+        "dishName": "Butternut Pumpkin And Fingerlime Tart",
+        "price": 22,
+        "image": "https://belindajeffery.com.au/wp-content/uploads/2017/02/butternut-pumpkin-maple-syrup-tart-1000x1000-c-center.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Salmon with Quinoa and Broccolini",
+        "price": 28.5,
+        "image": "https://i.pinimg.com/originals/f7/8d/b8/f78db86a5bcbf42e6402f135ff6da43f.jpg"
+      },
+      {
+        "dishName": "Veggie Burger with Sweet Potato Fries",
+        "price": 18,
+        "image": "https://external-preview.redd.it/hearty-veggie-burger-with-sweet-potato-fries-this-veggie-v0-Q-cqUUz9FMWfk2rG3myj0ci8DhBETIFkR4dDsxzLPig.jpg?width=1080&crop=smart&auto=webp&s=dddf0c7cc86dfb73918ecb166f743cda6761e3c4"
+      },
+      {
+        "dishName": "Chicken Caesar Salad Wrap",
+        "price": 15,
+        "image": "https://www.tasteandtellblog.com/wp-content/uploads/2017/04/Chicken-Caesar-Wraps-tasteandtellblog.com-1-768x1152.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/1b/2d/26/1b2d265c5349b1ec3e1dae256ecdb28a.jpg",
+    "storeId": 48
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Bistro Bliss",
+    "category": "Steakhouse",
+    "products": [
+      {
+        "dishName": "Cherry-infused Beef Roast",
+        "price": 42.99,
+        "image": "https://thumbs.dreamstime.com/b/roast-beef-cherry-sauce-style-rustic-selective-focus-192152732.jpg"
+      },
+      {
+        "dishName": "Grilled Filet Mignon",
+        "price": 29.95,
+        "image": "https://www.joyfulhealthyeats.com/wp-content/uploads/2023/07/Grilled-Filet-Mignon-Recipe-web-6.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Scallops",
+        "price": 24.99,
+        "image": "https://i2.wp.com/wonkywonderful.com/wp-content/uploads/2019/07/spicy-seared-scallops-3.jpg?ssl=1"
+      },
+      {
+        "dishName": "Roasted Vegetable Quinoa Bowl",
+        "price": 18.95,
+        "image": "https://feelgoodfoodie.net/wp-content/uploads/2022/01/Roasted-Vegetable-Quinoa-Bowl-06.jpg"
+      },
+      {
+        "dishName": "Seared Ahi Tuna Salad",
+        "price": 32.95,
+        "image": "https://kitskitchen.com/wp-content/uploads/2016/08/sesamecrustedahi3.jpg"
+      },
+      {
+        "dishName": "Braised Short Ribs",
+        "price": 36.99,
+        "image": "https://gardeninthekitchen.com/wp-content/uploads/2021/01/braised-beef-short-ribs_2482.jpg"
+      },
+      {
+        "dishName": "Crispy Duck Breast",
+        "price": 39.95,
+        "image": "https://images.deliveryhero.io/image/foodpanda/recipes/duck-breast-recipe-1.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=AjnYkaLIvGOqeap5ZDpzrFt&oh=00_AYA5fYbcB-GF3ZQsmQ7G6d5KYlmtWLPEk1yIF-ddSENqTA&oe=675D1821",
+    "storeId": 49
+  },
+  {
+    "cityName": "Bethel",
+    "storeName": "Mom's Kitchen Delights",
+    "category": "Deli & Specialty Foods",
+    "products": [
+      {
+        "dishName": "Classic Dill Pickle Slices",
+        "price": 4.99,
+        "image": "https://artofnaturalliving.com/wp-content/uploads/2011/07/Dill_Pickle_Slices_02-copy-1024x1024.jpg"
+      },
+      {
+        "dishName": "Bethel's Special Mustard Chicken Wings",
+        "price": 12.95,
+        "image": "https://i0.wp.com/southerncastiron.com/wp-content/uploads/2023/04/wings262jb2-scaled.jpeg"
+      },
+      {
+        "dishName": "Artisanal Pretzel Bites with Beer Cheese Dip",
+        "price": 8.5,
+        "image": "https://i.pinimg.com/originals/09/18/2b/09182bb3aa5011afa750dee55c17814f.jpg"
+      },
+      {
+        "dishName": "Homemade Coleslaw with a hint of Smoked Paprika",
+        "price": 6.25,
+        "image": "https://i.pinimg.com/originals/13/0d/38/130d38cb6d73e1240cb2c9dd8f068cc6.jpg"
+      },
+      {
+        "dishName": "Applewood-Smoked Bacon Wrapped Dates",
+        "price": 10.99,
+        "image": "https://i.pinimg.com/736x/b2/d5/db/b2d5db30848ec06910d03d24f644a22c.jpg"
+      },
+      {
+        "dishName": "Creamy Mashed Potato Topped Shepherd's Pie",
+        "price": 14.95,
+        "image": "https://www.unfussykitchen.com/wp-content/uploads/2020/10/shepherds-pie-image-5-1152x1536.jpg"
+      }
+    ],
+    "image": "https://c8.alamy.com/comp/2JY9KPA/mom-kitchen-logo-vector-illustration-with-modern-typography-chef-mascot-logo-2JY9KPA.jpg",
+    "storeId": 50
+  },
+  {
+    "cityName": "Athens",
+    "storeName": "Takis' Souvlaki House",
+    "category": "Greek Food",
+    "products": [
+      {
+        "dishName": "Classic Pork Souvlaki",
+        "price": 8.99,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/05/TMD-Pork-Souvlaki-WEB-26-1024x1536.jpg"
+      },
+      {
+        "dishName": "Chicken Gyro Wrap",
+        "price": 9.5,
+        "image": "https://www.twopeasandtheirpod.com/wp-content/uploads/2023/07/Chicken-Gyros-0666.jpg"
+      },
+      {
+        "dishName": "Souvlaki Combo (2 skewers, side salad)",
+        "price": 14.95,
+        "image": "https://www.seasonsandsuppers.ca/wp-content/uploads/2017/11/souvlaki-horiz4-3.jpg"
+      },
+      {
+        "dishName": "Grilled Halloumi Cheese",
+        "price": 7,
+        "image": "https://littlesunnykitchen.com/wp-content/uploads/2021/05/Grilled-Halloumi-1-1-1024x1536.jpg"
+      },
+      {
+        "dishName": "Greek Salad with Feta and Olives",
+        "price": 8.5,
+        "image": "https://www.jessicagavin.com/wp-content/uploads/2018/02/greek-salad-1.jpg"
+      },
+      {
+        "dishName": "Spanakopita (Spinach & Feta Pie)",
+        "price": 6.25,
+        "image": "https://www.olivetomato.com/wp-content/uploads/2020/05/Greek-spankopita-Spinach-and-feta-pie-940x723.jpeg"
+      },
+      {
+        "dishName": "Loukaniko Sausage Platter",
+        "price": 12.95,
+        "image": "https://www.healthy-delicious.com/wp-content/uploads/2021/11/homemade-beef-sausage-17-768x1152.jpg"
+      }
+    ],
+    "image": "https://takis.ca/themes/custom/bc_brand/logo.png",
+    "storeId": 51
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Sakura Restaurant",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Tonkatsu Curry",
+        "price": 12.99,
+        "image": "https://makedinnerplans.com/wp-content/uploads/2021/02/tonkatsu_curry-1536x1536.jpg"
+      },
+      {
+        "dishName": "Beef Katsu Bento",
+        "price": 14.5,
+        "image": "https://thebigmansworld.com/wp-content/uploads/2022/11/sliced-beef-katsu.jpeg"
+      },
+      {
+        "dishName": "Pork Tonkatsu Teishoku",
+        "price": 15,
+        "image": "https://www.thespruceeats.com/thmb/rB576pO_SS-InJFKMgsHWUG9syY=/3600x2403/filters:fill(auto,1)/tonkatsu-recipe-japanese-breaded-and-deep-fried-pork-2031274-hero-01-13c2048cc4a04aa087d472787430867e.jpg"
+      },
+      {
+        "dishName": "Chicken Katsu Curry Set",
+        "price": 13.25,
+        "image": "https://tildaricelive.s3.eu-central-1.amazonaws.com/wp-content/uploads/2021/06/22092411/Chicken-Katsu-Curry.jpg"
+      },
+      {
+        "dishName": "Vegetable Katsu Bento",
+        "price": 12.5,
+        "image": "https://thumbs.dreamstime.com/b/delicious-chicken-katsu-bento-box-rice-pickled-vegetables-tamagoyaki-delicious-chicken-katsu-bento-box-rice-pickled-278460248.jpg"
+      },
+      {
+        "dishName": "Deep-Fried Chicken Karaage",
+        "price": 11.75,
+        "image": "https://static01.nyt.com/images/2018/07/25/dining/HK-karaage-horizontal/merlin_141075300_74569dec-9fc2-4174-931d-019dddef3bb8-threeByTwoMediumAt2X.jpg"
+      }
+    ],
+    "image": "https://media-cdn.tripadvisor.com/media/photo-s/1a/77/73/36/sakura-logo-2020.jpg",
+    "storeId": 52
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Mangia Italiano",
+    "category": "Italian Food",
+    "products": [
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 18.99,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 16.49,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4-728x1092.jpg"
+      },
+      {
+        "dishName": "Jameson's Special Marigold",
+        "price": 12.95,
+        "image": "https://i.ebayimg.com/images/g/nkkAAOSwWo1l3pCh/s-l1600.jpg"
+      },
+      {
+        "dishName": "Vegetable Lasagna",
+        "price": 14.99,
+        "image": "https://anothertablespoon.com/wp-content/uploads/2017/10/DSC07712.jpg"
+      },
+      {
+        "dishName": "Eggplant Parmesan",
+        "price": 15.49,
+        "image": "https://thestayathomechef.com/wp-content/uploads/2018/07/Eggplant-Parmesan-3-small-1.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 8.95,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      }
+    ],
+    "image": "https://robertbree.de/wp-content/uploads/Mangia-italiano-logo-schriftzug.jpg",
+    "storeId": 53
+  },
+  {
+    "cityName": "New Orleans",
+    "storeName": "Cafe du Monde",
+    "category": "Italian Restaurant",
+    "products": [
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 14.99,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 12.99,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Otho's Special Semolina",
+        "price": 16.99,
+        "image": "https://i0.wp.com/simplyvegetarian777.com/wp-content/uploads/2017/04/IMG_1174-e1514052792566.jpg?fit=1500%2C2000&ssl=1"
+      },
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 13.49,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4-728x1092.jpg"
+      },
+      {
+        "dishName": "Garlic Shrimp Linguine",
+        "price": 15.99,
+        "image": "https://media.chefdehome.com/740/0/0/shrimp-scampi/garlic-shrimp-scampi-linguine.jpg"
+      },
+      {
+        "dishName": "Eggplant Parmesan",
+        "price": 14.49,
+        "image": "https://cdn.apartmenttherapy.info/image/fetch/f_auto,q_auto:eco/https://storage.googleapis.com/gen-atmedia/3/2018/08/c024bcfedd6354f883f878c103ce47b51e919697.jpeg"
+      }
+    ],
+    "image": "https://shop.cafedumonde.com/wp-content/uploads/2018/11/q10b.jpg",
+    "storeId": 54
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Lasagna Classica",
+        "price": 14.95,
+        "image": "https://img.freepik.com/foto-gratis/lasana-clasica-salsa-bolonesa_2829-11250.jpg?w=1380&t=st=1685489177~exp=1685489777~hmac=2711dcc42ccfbb117a99ca53621fd878a9370179c210a841edbf17c5fbbfc21f"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 12.95,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Bruschetta Italiano",
+        "price": 8.95,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 10.95,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Tiramisu",
+        "price": 7.95,
+        "image": "https://littlesunnykitchen.com/wp-content/uploads/2021/01/Easy-Tiramisu-Recipe-2-1024x1536.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 55
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Tokyo Bay Sushi House",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Philadelphia Roll",
+        "price": 12.99,
+        "image": "https://img.buzzfeed.com/thumbnailer-prod-us-east-1/696c264b93bf424ba0b8a0abdde8de80/BFV30104_SushiDinnerForTwo_FB_NiNo_Final.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Maki",
+        "price": 10.99,
+        "image": "http://twomarketgirls.com/wp-content/uploads/2019/03/IMG_0002-1.jpg?is-pending-load=1"
+      },
+      {
+        "dishName": "Crunchy California Roll",
+        "price": 11.49,
+        "image": "https://knifeandsoul.com/wp-content/uploads/2022/09/crunchy-roll-sushi-recipe-recipe-card.jpg"
+      },
+      {
+        "dishName": "Salmon Nigiri",
+        "price": 14.99,
+        "image": "https://izzycooking.com/wp-content/uploads/2020/10/Salmon-Nigiri-1-683x1024.jpg"
+      },
+      {
+        "dishName": "Shrimp Tempura Maki",
+        "price": 13.99,
+        "image": "https://c8.alamy.com/comp/2GDFRXM/shrimp-tempura-maki-sushi-japanese-food-2GDFRXM.jpg"
+      },
+      {
+        "dishName": "Unagi Donburi",
+        "price": 16.99,
+        "image": "https://www.chopstickchronicles.com/wp-content/uploads/2023/06/Unadon-12.webp"
+      }
+    ],
+    "image": "https://www.tokyobaysushi.ro/wp-content/uploads/2022/10/logo.png",
+    "storeId": 56
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Tasmanian Fusion",
+    "category": "Asian-Fusion",
+    "products": [
+      {
+        "dishName": "Pan-Seared Wagyu Beef",
+        "price": 42.99,
+        "image": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEiZ-sfkhqMnKfiz7571weUVul95mtyWP5FoW4-39EGvPHXwAjWdy0wlhwrsyEtbseuzCGJvApdoTjLOEtq9G5yeG4cCRSz0Lomj_8m0y7pTI4TjM-aur84OhK2zYYP032SzpxboIAZk8CXjdYQU5MTjZmcvK2NMyDHfJ2pBka2dtbqMSdfY4ShseqK4/s4032/20221125_120523.jpg"
+      },
+      {
+        "dishName": "Dried Apricot-glazed Emu Skewers",
+        "price": 25.5,
+        "image": "https://assets.bonappetit.com/photos/57b0dbaff1c801a1038bda81/master/pass/dire_kebabs_v.jpg"
+      },
+      {
+        "dishName": "Spicy Prawn and Scallop Stir Fry",
+        "price": 31.75,
+        "image": "https://cmx.weightwatchers.com/assets-proxy/weight-watchers/image/upload/t_WINE_EXTRALARGE/ohv5nlchi3anhqrvv1hl.jpg"
+      },
+      {
+        "dishName": "Steamed Mussels in Lemongrass Broth",
+        "price": 22.95,
+        "image": "https://lepetiteats.com/wp-content/uploads/2021/10/IMG_9338-1-500x500.jpg"
+      },
+      {
+        "dishName": "Char-Grilled Lamb Chops with Rosemary and Garlic",
+        "price": 38.25,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2016/12/Rosemary-Garlic-Marinated-Lamb-Chops-5.jpg?resize=85"
+      },
+      {
+        "dishName": "Thai Green Curry with Chicken and Vegetables",
+        "price": 28.9,
+        "image": "https://www.kitchensanctuary.com/wp-content/uploads/2019/06/Thai-Green-Curry-png.png"
+      }
+    ],
+    "image": "http://seeklogo.com/images/T/Tasmania-logo-1741D7E4F3-seeklogo.com.gif",
+    "storeId": 57
+  },
+  {
+    "cityName": "Bangkok",
+    "storeName": "Lao Kitchen",
+    "category": "Southeast Asian",
+    "products": [
+      {
+        "dishName": "Sour Laotian Stew (Nam Khao)",
+        "price": 8.99,
+        "image": "https://www.cookeatworld.com/wp-content/uploads/2020/10/NamKhao15-800x1203.jpg"
+      },
+      {
+        "dishName": "Grilled Pork Skewers (Moo Ping)",
+        "price": 9.49,
+        "image": "https://www.seriouseats.com/thmb/JJy5k1q5coAa0kL49BH0iLTwXc8=/1500x1125/filters:fill(auto,1)/__opt__aboutcom__coeus__resources__content_migration__serious_eats__seriouseats.com__2019__07__20190618-grilled-thai-pork-skewers-vicky-wasik-13-8b3614c8f6234187abf1396973a4eeea.jpg"
+      },
+      {
+        "dishName": "Stir-Fried Basil Leaves with Chilies",
+        "price": 7.99,
+        "image": "https://img.taste.com.au/BsxLfJBs/taste/2020/01/basil-chilli-chicken-stir-fry-158000-1.jpg"
+      },
+      {
+        "dishName": "Laotian-Style Fried Chicken",
+        "price": 10.99,
+        "image": "https://i.pinimg.com/originals/d3/21/6c/d3216c604c116e5d314918179270921d.jpg"
+      },
+      {
+        "dishName": "Spicy Papaya Salad (Tam Maak Hoong)",
+        "price": 8.49,
+        "image": "https://images.squarespace-cdn.com/content/v1/5fee116050339566e9b38f09/ce808c38-cd3c-4114-8921-4f5746153c87/IMG_9395.jpg"
+      },
+      {
+        "dishName": "Steamed Jasmine Rice",
+        "price": 2.99,
+        "image": "https://more.ctv.ca/content/dam/ctv/uploadImg/2020/11/16/115928_steam%20jasmine%20rice.jpg"
+      },
+      {
+        "dishName": "Fried Wontons with Sweet Chili Sauce",
+        "price": 6.99,
+        "image": "https://c8.alamy.com/comp/2M8D3C8/chinese-wontons-with-sweet-chilli-dip-sauce-and-chop-sticks-asian-fried-dumplings-with-soy-sauce-on-white-dish-asian-fried-dumplings-wontons-with-soy-2M8D3C8.jpg"
+      }
+    ],
+    "image": "https://i0.wp.com/laothaikitchen.com/wp-content/uploads/2020/04/Logo.png?fit=3690%2C2384&ssl=1",
+    "storeId": 58
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Bistro Bliss",
+    "category": "Cafe",
+    "products": [
+      {
+        "dishName": "Fig And Blood Orange Tart",
+        "price": 8.99,
+        "image": "https://sp-ao.shortpixel.ai/client/to_webp,q_lossless,ret_img,w_700,h_1050/http://www.useyournoodles.eu/wp-content/uploads/dried-fig-blood-orange-tart-14.jpg"
+      },
+      {
+        "dishName": "French Onion Soup",
+        "price": 6.49,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2021/12/Classic-French-Onion-Soup-2-scaled.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken Salad",
+        "price": 12.95,
+        "image": "https://gimmesomegrilling.com/wp-content/uploads/2021/05/Grilled-Chicken-Salad-Recipe-Square.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Salmon",
+        "price": 18.99,
+        "image": "https://www.dinneratthezoo.com/wp-content/uploads/2019/04/pan-seared-salmon-3.jpg"
+      },
+      {
+        "dishName": "Roasted Vegetable Wrap",
+        "price": 7.49,
+        "image": "https://4.bp.blogspot.com/-KfIOFgmFZ5U/TwOulUrpd3I/AAAAAAAABsI/6b5X0tGybCs/s1600/P1030455.JPG"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=AGWiULob-8pxcnER_RClh5A&oh=00_AYBnIFW3ko3zoiYA6ZI-62SYADnN57mAtGN50Fhyn_DT_Q&oe=675D1821",
+    "storeId": 59
+  },
+  {
+    "cityName": "Singapore",
+    "storeName": "Nona's Kitchen",
+    "category": "Southeast Asian Cuisine",
+    "products": [
+      {
+        "dishName": "Peranakan Chicken Curry",
+        "price": 12.9,
+        "image": "https://c8.alamy.com/comp/CXWNXJ/peranakan-chicken-curry-malaysian-food-CXWNXJ.jpg"
+      },
+      {
+        "dishName": "Sambal Prawn Fried Rice",
+        "price": 9.5,
+        "image": "https://www.licious.in/blog/wp-content/uploads/2022/07/shutterstock_1582779079.jpg"
+      },
+      {
+        "dishName": "Kueh Pie Tee (Carrot Cake)",
+        "price": 6.8,
+        "image": "https://www.alamy.com/aggregator-api/download?url=https://c8.alamy.com/comp/AJN430/singapore-fantastic-dish-called-kueh-pie-tee-a-nonya-dish-pastry-case-AJN430.jpg"
+      },
+      {
+        "dishName": "Ayam Buah Keluak",
+        "price": 15.9,
+        "image": "https://media.timeout.com/images/103315191/image.jpg"
+      },
+      {
+        "dishName": "Roti Prata with Curry Sauce",
+        "price": 8.2,
+        "image": "https://thumbs.dreamstime.com/z/indian-roti-prata-condensed-milk-curry-sauce-close-up-rustic-fried-pancake-93287527.jpg"
+      },
+      {
+        "dishName": "Char Kway Teow (Stir-Fried Noodles)",
+        "price": 10.5,
+        "image": "https://thatspicychick.com/wp-content/uploads/2022/07/Char-Kway-Teow-black-plate-768x1152.jpg"
+      }
+    ],
+    "image": "http://www.nonas.in/wp-content/uploads/2023/05/cropped-favicon.png",
+    "storeId": 60
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Osteria della Buona Fortuna",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Bruschetta con Pomodoro",
+        "price": 8.5,
+        "image": "https://c8.alamy.com/compit/pbxyw3/bruschetta-con-pomodoro-mozzarella-e-basilico-su-un-vecchio-tavolo-rustico-italiano-tradizionale-di-un-aperitivo-o-uno-snack-antipasto-pbxyw3.jpg"
+      },
+      {
+        "dishName": "Spaghetti alla Carbonara",
+        "price": 14,
+        "image": "https://www.sipandfeast.com/wp-content/uploads/2019/02/spaghetti-carbonara-recipe-6.jpg"
+      },
+      {
+        "dishName": "Pollo al Marsala",
+        "price": 12,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2020/02/chicken-marsala-02.jpg"
+      },
+      {
+        "dishName": "Fettuccine con Funghi e Tartufo",
+        "price": 16.5,
+        "image": "https://www.areada.it/wp-content/uploads/fettuccine-funghi-e-tartufo.jpg"
+      },
+      {
+        "dishName": "Risotto alla Milanese",
+        "price": 18,
+        "image": "https://i.pinimg.com/originals/a1/b9/36/a1b9367f8eb4525534fd8b24b2b70843.jpg"
+      },
+      {
+        "dishName": "Torta di Ricotta e Frutta",
+        "price": 6.5,
+        "image": "https://blog.giallozafferano.it/ipasticcinidinina/wp-content/uploads/2021/12/Torta-cremosa-di-ricotta-e-frutta-secca-2-1536x1152.jpg"
+      }
+    ],
+    "image": "https://i.etsystatic.com/6509702/r/il/44057e/1390651200/il_794xN.1390651200_ca7r.jpg",
+    "storeId": 61
+  },
+  {
+    "cityName": "Portland",
+    "storeName": "Bistro Bliss",
+    "category": "Cafe/Bakery",
+    "products": [
+      {
+        "dishName": "French Press Coffee",
+        "price": 4.5,
+        "image": "https://craftcoffeespot.com/wp-content/uploads/2021/09/French-Press-pour-out-1024x1024.png"
+      },
+      {
+        "dishName": "Avocado Toast",
+        "price": 8.95,
+        "image": "http://static1.squarespace.com/static/60f9bc54b58d9f20a4dbc2c4/60fb3889d8f5e37d30bd806a/62a09f51abe961756420c839/1654701631660/IMG_4169a.JPG?format=1500w"
+      },
+      {
+        "dishName": "Quiche Lorraine",
+        "price": 12,
+        "image": "http://images.media-allrecipes.com/userphotos/960x960/7787187.jpg"
+      },
+      {
+        "dishName": "Cherry And Avocado Tart",
+        "price": 16.5,
+        "image": "https://eightydishes.com/wp-content/uploads/2020/05/Fresh-Cherry-Tart-Thumbnail-1024x1024.jpg"
+      },
+      {
+        "dishName": "Spinach and Feta Quiche",
+        "price": 14.25,
+        "image": "https://www.kayscleaneats.com/wp-content/uploads/2019/10/dsc_0364-scaled.jpg"
+      },
+      {
+        "dishName": "Cinnamon Roll Waffle Sandwich",
+        "price": 10.75,
+        "image": "http://images.heb.com/is/image/HEBGrocery/recipe-hm-large/cinnamon-roll-waffle-breakfast-sandwich-recipe.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=ATI-1lS1K1gD8wps6CDa8HO&oh=00_AYB1NEDyQ63VitheNi8BdpQYnw4Ehxsg3POhCF3k1_8WpQ&oe=675D1821",
+    "storeId": 62
+  },
+  {
+    "cityName": "New Orleans",
+    "storeName": "Bistro du Coin",
+    "category": "Fine Dining",
+    "products": [
+      {
+        "dishName": "Pot Marjoram-crusted Quail",
+        "price": 25.99,
+        "image": "https://cdn9.dissolve.com/p/D1062_54_347/D1062_54_347_1200.jpg"
+      },
+      {
+        "dishName": "Pan-seared Duck Breast",
+        "price": 32.95,
+        "image": "https://www.wellseasonedstudio.com/wp-content/uploads/2020/11/Seared-duck-breast-with-duck-fat-potatoes-on-a-plate.jpg"
+      },
+      {
+        "dishName": "Roasted Garlic Mashed Potatoes",
+        "price": 7.95,
+        "image": "https://www.simplyrecipes.com/thmb/TI1BDtL9k1kueIjZTDVm0qpGJt8=/3867x5801/filters:fill(auto,1)/Simply-Recipes-Garlic-Mashed-Potatoes-Lead-2-196ad1405f1c400a8e47d2142b4aba1b.jpg"
+      },
+      {
+        "dishName": "Grilled Asparagus with Lemon Aioli",
+        "price": 12.99,
+        "image": "https://www.flavourandsavour.com/wp-content/uploads/2023/03/asparagus-with-lemon-aioli-1.jpg"
+      },
+      {
+        "dishName": "Crispy Fried Green Tomatoes",
+        "price": 9.95,
+        "image": "https://i1.wp.com/www.melissassouthernstylekitchen.com/wp-content/uploads/2020/05/FriedGreenTomatoes001feature.jpg?fit=1200,1200&ssl=1"
+      },
+      {
+        "dishName": "Creamy Tomato Soup",
+        "price": 8.99,
+        "image": "https://platedcravings.com/wp-content/uploads/2017/09/Creamy-Roasted-Tomato-Basil-Soup-Plated-Cravings-4.jpg"
+      },
+      {
+        "dishName": "Herb-roasted Chicken Breast",
+        "price": 19.95,
+        "image": "https://i2.wp.com/www.downshiftology.com/wp-content/uploads/2021/04/Herb-Baked-Chicken-Breast-11.jpg"
+      }
+    ],
+    "image": "https://cdn.netspace.ma/wp-content/uploads/2022/05/BrowserPreview_tmp.jpg?strip=all&lossy=1&ssl=1&fit=1920%2C918",
+    "storeId": 63
+  },
+  {
+    "cityName": "Durban",
+    "storeName": "Bunny's Paradise",
+    "category": "Indian",
+    "products": [
+      {
+        "dishName": "Lamb Bunny Chow",
+        "price": 15.99,
+        "image": "https://c8.alamy.com/comp/2JYJ8X6/closeup-of-lamb-bunny-chow-the-popular-indian-fast-food-cuisine-which-originated-in-south-africa-with-carrot-salad-on-plate-on-the-table-horizontal-2JYJ8X6.jpg"
+      },
+      {
+        "dishName": "Vegetable Bunny Chow",
+        "price": 12.99,
+        "image": "https://assets.unileversolutions.com/recipes-v2/163147.jpg?imwidth=900"
+      },
+      {
+        "dishName": "Chicken Tikka Bunny Chow",
+        "price": 14.99,
+        "image": "https://www.lentils.org/wp-content/uploads/2019/05/Sask-Pulse-Growers-Chicken-Tikka-Bunny-Chow-5906.jpg"
+      },
+      {
+        "dishName": "Butter Chicken Bunny Chow",
+        "price": 16.49,
+        "image": "https://www.withablast.net/wp-content/uploads/2018/02/Butter-Chicken-Bunny-Chow-e.jpg"
+      },
+      {
+        "dishName": "Meat Bunny Chow (beef)",
+        "price": 13.99,
+        "image": "https://assets.unileversolutions.com/recipes-v2/163147.jpg?imwidth=900"
+      },
+      {
+        "dishName": "Samosa Fries",
+        "price": 8.99,
+        "image": "http://www.zedamagazine.com/wp-content/uploads/2018/06/Indian-Food-Samosa-Dish-HD-Wallpapers.jpg"
+      },
+      {
+        "dishName": "Garlic Naan Bread",
+        "price": 3.49,
+        "image": "https://www.spiceupthecurry.com/wp-content/uploads/2022/09/garlic-naan-2.jpg"
+      }
+    ],
+    "image": "https://bunny-paradise-world.com/wp-content/themes/bunny-paradise-world/images/ogp.png",
+    "storeId": 64
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Sushi Ichiban",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Salmon Nigiri",
+        "price": 12,
+        "image": "https://izzycooking.com/wp-content/uploads/2020/10/Salmon-Nigiri-2.jpg"
+      },
+      {
+        "dishName": "California Roll",
+        "price": 10,
+        "image": "https://www.simplyrecipes.com/thmb/RO934yz6fcEFphwCIJyaQWt9siI=/3843x2562/filters:no_upscale():max_bytes(150000):strip_icc()/Simply-Recipes-California-Roll-LEAD-05-3c3a2fb4a9034e5c8cb34d6a24d9731e.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Sashimi",
+        "price": 14,
+        "image": "https://i.pinimg.com/originals/57/57/7f/57577ff8a2d7b462aec85e465032edaf.jpg"
+      },
+      {
+        "dishName": "Tempura Shrimp Udon",
+        "price": 18,
+        "image": "https://sudachirecipes.com/wp-content/uploads/2022/05/ebiten-udon-sq.jpg"
+      },
+      {
+        "dishName": "Tonkatsu Bento",
+        "price": 15,
+        "image": "https://i.pinimg.com/originals/d7/3c/69/d73c69ea573df14aa7f55018237b5582.jpg"
+      },
+      {
+        "dishName": "Miso Soup",
+        "price": 4,
+        "image": "https://www.thespruceeats.com/thmb/q5pzZZKO021eP9s4x_-Mq6m_I8Q=/4494x3000/filters:fill(auto,1)/basic-miso-soup-3377886_09-5b3f7fb6c9e77c00378bf68f.jpg"
+      }
+    ],
+    "image": "http://www.dpmallsemarang.com/wp-content/uploads/2019/08/12.-ICHIBAN-SUSHI-reduce.jpg",
+    "storeId": 65
+  },
+  {
+    "cityName": "Taipei",
+    "storeName": "Lucky Noodle House",
+    "category": "Street Food",
+    "products": [
+      {
+        "dishName": "Stinky Tofu",
+        "price": 120,
+        "image": "https://knowinsiders.com/stores/news_dataimages/linhtd/112020/17/22/2231_weirdest-dish-in-the-world-Stinky-Tofu4.jpg?rt=20201117222235?randTime=1610747723"
+      },
+      {
+        "dishName": "Oyster Omelet",
+        "price": 100,
+        "image": "https://i.pinimg.com/originals/ae/23/9a/ae239a64a5b5c2cf7bf0a080c0c0685a.jpg"
+      },
+      {
+        "dishName": "Gua Bao",
+        "price": 80,
+        "image": "https://www.dishbyrish.co.uk/wp-content/uploads/2021/03/IMG_20200407_181113_068.jpg"
+      },
+      {
+        "dishName": "Fried Chicken Wings",
+        "price": 60,
+        "image": "https://heartscontentfarmhouse.com/wp-content/uploads/2022/10/recipe-card-deep-fried-wings.jpg"
+      },
+      {
+        "dishName": "Stir-Fried Cabbage",
+        "price": 40,
+        "image": "https://redhousespice.com/wp-content/uploads/2020/10/Stir-fried-Napa-Cabbage-8-scaled.jpg"
+      },
+      {
+        "dishName": "Taiwanese Beef Noodle Soup",
+        "price": 180,
+        "image": "https://myformosafood.com/wp-content/uploads/2020/08/11-2.jpg"
+      },
+      {
+        "dishName": "Braised Pork Belly",
+        "price": 200,
+        "image": "https://umamidays.com/wp-content/uploads/2022/11/red-braised-pork-belly.jpg"
+      }
+    ],
+    "image": "https://img.freepik.com/premium-vector/noodle-house-logo-template_79169-36.jpg?w=2000",
+    "storeId": 66
+  },
+  {
+    "cityName": "Los Angeles",
+    "storeName": "Sushi Palace",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "California Maki",
+        "price": 12.99,
+        "image": "http://4.bp.blogspot.com/-raMHZoWtIsY/UUc5tAwxBKI/AAAAAAAAAMY/v2seIuuyOqM/s1600/WP_002877.jpg"
+      },
+      {
+        "dishName": "Salmon Sashimi",
+        "price": 15.99,
+        "image": "https://lenaskitchenblog.com/wp-content/uploads/2021/08/Salmon-Sushi-8.jpg"
+      },
+      {
+        "dishName": "Shrimp Tempura",
+        "price": 10.49,
+        "image": "https://simplyhomecooked.com/wp-content/uploads/2019/12/shrimp-tempura-recipe-8.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Roll",
+        "price": 11.99,
+        "image": "https://tastesbetterfromscratch.com/wp-content/uploads/2023/01/Spicy-Tuna-Roll-15.jpg"
+      },
+      {
+        "dishName": "Miso Soup",
+        "price": 4.99,
+        "image": "https://www.thespruceeats.com/thmb/q5pzZZKO021eP9s4x_-Mq6m_I8Q=/4494x3000/filters:fill(auto,1)/basic-miso-soup-3377886_09-5b3f7fb6c9e77c00378bf68f.jpg"
+      },
+      {
+        "dishName": "Gyoza",
+        "price": 9.99,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2020/09/Gyoza-Recipe-021-scaled.jpg"
+      }
+    ],
+    "image": "https://tb-static.uber.com/prod/image-proc/processed_images/821b4ef3a581328d2b81d146708035df/3ac2b39ad528f8c8c5dc77c59abb683d.jpeg",
+    "storeId": 67
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Pasta With Tomato And Basil",
+        "price": 12.95,
+        "image": "https://lexiscleankitchen.com/wp-content/uploads/2021/07/Fresh-Tomato-Pasta-6.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 14.5,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 15,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 8.95,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 10.5,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7-683x1024.jpg"
+      },
+      {
+        "dishName": "Garlic Shrimp",
+        "price": 18,
+        "image": "https://www.eatwell101.com/wp-content/uploads/2021/06/Garlic-Butter-Shrimp-4.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 68
+  },
+  {
+    "cityName": "Beijing",
+    "storeName": "Golden Wok",
+    "category": "Cantonese/Beijing Cuisine",
+    "products": [
+      {
+        "dishName": "Peking Duck (Whole)",
+        "price": 29.99,
+        "image": "https://thumbs.dreamstime.com/b/dish-whole-roasted-peking-duck-thailand-250952474.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Dumplings (6 pieces)",
+        "price": 8.99,
+        "image": "http://2.bp.blogspot.com/-Ek3yYXa_4jM/Uzepx_IFWiI/AAAAAAAAEGI/tI9CG7f8mEk/s1600/videos,+dumplings,veggie+nuggets+150.JPG"
+      },
+      {
+        "dishName": "Kung Pao Chicken",
+        "price": 14.99,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2020/02/kung-pao-chicken-1-1024x1536.jpg"
+      },
+      {
+        "dishName": "Steamed Edamame",
+        "price": 4.99,
+        "image": "https://eatsbythebeach.com/wp-content/uploads/2022/08/Asian-Steamed-Edamame-1-Eats-By-The-Beach-683x1024.jpeg"
+      },
+      {
+        "dishName": "Stir-Fried Bok Choy",
+        "price": 6.99,
+        "image": "https://ohsnapletseat.com/wp-content/uploads/2020/11/IMG_0873-scaled.jpg"
+      },
+      {
+        "dishName": "Beef and Broccoli Stir Fry",
+        "price": 16.99,
+        "image": "https://www.jocooks.com/wp-content/uploads/2019/04/beef-and-broccoli-1-11.jpg"
+      },
+      {
+        "dishName": "Cantonese-Style Roast Pork",
+        "price": 19.99,
+        "image": "https://tastycooking.recipes/.netlify/images?url=/images/cantonese-style-roast-pork-belly.jpg"
+      }
+    ],
+    "image": "https://img.freepik.com/premium-vector/flat-asian-food-golden-wok-stamp-logo-vector-illustration_723710-241.jpg",
+    "storeId": 69
+  },
+  {
+    "cityName": "Wellington",
+    "storeName": "The Sweet Spot",
+    "category": "Café/Bakery",
+    "products": [
+      {
+        "dishName": "Fresh Fruit Salad",
+        "price": 12.95,
+        "image": "https://cdn3.tmbi.com/secure/RMS/attachments/37/1200x1200/Layered-Fresh-Fruit-Salad_EXPS_HCA18_2778_B04_26_3b.jpg"
+      },
+      {
+        "dishName": "Feijoa And Pineapple Tart",
+        "price": 8.5,
+        "image": "https://olharfeliz.typepad.com/photos/uncategorized/2008/11/10/pineapple_guava_tart_tarte_au_feijo.jpg"
+      },
+      {
+        "dishName": "Cinnamon Swirl Coffee Cake",
+        "price": 5.25,
+        "image": "https://blogger.googleusercontent.com/img/b/R29vZ2xl/AVvXsEjfMVJdQnHYviNa4kodnAATbA5DotWJC-pr0z8xXghEKfKLNumsHFWUrgs4JvhYSrSycCbf6nMaGUA-5vG0Cd9sb_J-Q-QaDFAFSHy1D3ty1OokQ-CDi6MV89kGM3R88ltKaab0C2eHCMZ48NAqYLngM9a5GI-lNPJHYiQTOKY4DjAzR-LIvXciw5n0/s1000/7xW28DkZWcdnuRo.jpg"
+      },
+      {
+        "dishName": "Quiche Lorraine",
+        "price": 14.95,
+        "image": "https://tasteofmissions.com/wp-content/uploads/2021/07/image.jpeg"
+      },
+      {
+        "dishName": "Greek Salad Wrap",
+        "price": 10.5,
+        "image": "https://realfoodbydad.com/wp-content/uploads/2019/10/Mediterranean-Greek-Salad-Wrap-Real-Food-by-Dad.jpg"
+      },
+      {
+        "dishName": "Chicken and Avocado Salsa Tacos",
+        "price": 16.25,
+        "image": "https://somethingnutritiousblog.com/wp-content/uploads/2024/01/19C1D529-C1FE-4A46-B534-1EA1B1B2374C-1152x1536.jpeg"
+      },
+      {
+        "dishName": "Roasted Vegetable Panini",
+        "price": 11.75,
+        "image": "https://img.taste.com.au/GEGmsFpE/taste/2016/11/roasted-vegetable-panini-109563-1.jpeg"
+      }
+    ],
+    "image": "https://s3-ap-southeast-2.amazonaws.com/foodservice-australia-production/The-Sweet-Spot-logo.png",
+    "storeId": 70
+  },
+  {
+    "cityName": "Miami",
+    "storeName": "Tropical Taste",
+    "category": "International",
+    "products": [
+      {
+        "dishName": "Savanna's Special Mango",
+        "price": 12.99,
+        "image": "https://assets.architecturaldigest.in/photos/60083d92e6e1f647401891f4/master/w_1600%2Cc_limit/Mango-mango-recipe-dishes-restaurants-most-delicious_1-1.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken Fajitas",
+        "price": 16.95,
+        "image": "https://easyweeknightrecipes.com/wp-content/uploads/2021/07/grilled-chicken-fajitas-6.jpg"
+      },
+      {
+        "dishName": "Spicy Shrimp Stir Fry",
+        "price": 14.75,
+        "image": "https://thegourmetcookbook.com/wp-content/uploads/2023/04/Spicy-Garlic-Shrimp-Stir-Fry-Recipe-1680623155913.jpg"
+      },
+      {
+        "dishName": "Bengali Lamb Korma",
+        "price": 18.99,
+        "image": "https://www.simplyrecipes.com/thmb/AyR0PbBIdzhRF2G9IQ-nUxIpp7s=/1600x1067/filters:fill(auto,1)/__opt__aboutcom__coeus__resources__content_migration__simply_recipes__uploads__2013__05__lamb-korma-horiz-a-1600-b08d7aa4f6df47f9bb0dbf40c206e0ad.jpg"
+      },
+      {
+        "dishName": "Jerk Chicken Wrap",
+        "price": 10.5,
+        "image": "http://cdn.shopify.com/s/files/1/0271/7895/8948/articles/IMG_20200722_123147_1200x1200.jpg?v=1625221469"
+      },
+      {
+        "dishName": "Vegetable Spring Rolls",
+        "price": 9.25,
+        "image": "https://www.tashasartisanfoods.com/blog/wp-content/uploads/2019/11/Baked-Veg-Spring-Rolls-6.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/6d/5b/6a/6d5b6a8fa6a3c5a4b15fb57aba0d6e4e.jpg",
+    "storeId": 71
+  },
+  {
+    "cityName": "Berlin",
+    "storeName": "Turkish Delight",
+    "category": "Fast Food",
+    "products": [
+      {
+        "dishName": "Adana Kebab",
+        "price": 8.99,
+        "image": "https://cdn.tasteatlas.com/images/dishes/3ab81ec46f604f85bcc3cc51fd17c446.jpg"
+      },
+      {
+        "dishName": "Chicken Shawarma",
+        "price": 7.49,
+        "image": "https://www.indianhealthyrecipes.com/wp-content/uploads/2023/05/chicken-shawarma-recipe.jpg"
+      },
+      {
+        "dishName": "Lamb Kofte",
+        "price": 9.99,
+        "image": "https://img.delicious.com.au/gnN8UHQn/w1200/del/2021/11/roasted-sumac-lamb-kofte-with-chickpeas-and-feta-159136-1.jpg"
+      },
+      {
+        "dishName": "Falafel Wrap",
+        "price": 6.99,
+        "image": "https://pickyeaterblog.com/wp-content/uploads/2022/11/healthy-falafel-wrap-recipe.jpg"
+      },
+      {
+        "dishName": "Doner Kebab",
+        "price": 10.49,
+        "image": "https://www.skipthedishes.com/foodwiki/uploads/2019/08/doner_kebab_2-1080x960.jpg"
+      },
+      {
+        "dishName": "Vegetable Kebab",
+        "price": 8.29,
+        "image": "https://keyassets-p2.timeincuk.net/wp/prod/wp-content/uploads/sites/53/2019/07/veggie-kebabs.jpg"
+      }
+    ],
+    "image": "https://img.freepik.com/premium-vector/turkish-delight-logo-template-vector-illustration-sketch-style_521900-1589.jpg",
+    "storeId": 72
+  },
+  {
+    "cityName": "Austin",
+    "storeName": "El Patio Mexican Grill",
+    "category": "Mexican",
+    "products": [
+      {
+        "dishName": "Chicken Fajitas",
+        "price": 14.99,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2021/04/Chicken-Fajitas-011-scaled.jpg"
+      },
+      {
+        "dishName": "Beef Tacos",
+        "price": 10.99,
+        "image": "https://www.jocooks.com/wp-content/uploads/2020/08/ground-beef-tacos-1-11.jpg"
+      },
+      {
+        "dishName": "Carne Asada Burrito",
+        "price": 12.99,
+        "image": "https://healthyschoolrecipes.com/wp-content/uploads/2021/05/carne-asada-burrito-scaled.jpg"
+      },
+      {
+        "dishName": "Quesadillas",
+        "price": 9.99,
+        "image": "https://cdn.momsdish.com/wp-content/uploads/2021/04/Chicken-Quesadillas012-scaled.jpg"
+      },
+      {
+        "dishName": "Guacamole",
+        "price": 7.99,
+        "image": "https://www.cubesnjuliennes.com/wp-content/uploads/2021/02/Homemade-Guacamole-Recipe.jpg"
+      },
+      {
+        "dishName": "Sopes de Chorizo",
+        "price": 11.99,
+        "image": "https://www.maricruzavalos.com/wp-content/uploads/2022/10/sopes-de-chorizo-recipe.jpg"
+      },
+      {
+        "dishName": "Enchiladas Rojas",
+        "price": 13.99,
+        "image": "https://www.muydelish.com/wp-content/uploads/2022/01/enchilada-rojas.jpg"
+      }
+    ],
+    "image": "https://toast-sites-prod.nyc3.cdn.digitaloceanspaces.com/restaurantImages/9b97da4a-df11-4daa-85f2-12fcfce9c15a/El%20Patio%20Logo.jpg",
+    "storeId": 73
+  },
+  {
+    "cityName": "Shanghai",
+    "storeName": "Din Tai Fung",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Pork Belly Buns",
+        "price": 8.99,
+        "image": "http://culinessa.com/wp-content/uploads/2014/04/IMG_4984.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken",
+        "price": 12.5,
+        "image": "https://cafedelites.com/wp-content/uploads/2018/04/Best-Kung-Pao-Chicken-IMAGE-2.jpg"
+      },
+      {
+        "dishName": "Steamed Dumplings",
+        "price": 10,
+        "image": "https://recipetineats.com/wp-content/uploads/2020/02/Siu-Mai_Chinese-steamed-dumplings_2.jpg"
+      },
+      {
+        "dishName": "Beef Noodle Soup",
+        "price": 9.75,
+        "image": "https://i.pinimg.com/originals/99/0d/7a/990d7a4ac6b827f89fe9e3d61873613a.jpg"
+      },
+      {
+        "dishName": "Spicy Wonton Soup",
+        "price": 11.25,
+        "image": "https://images.squarespace-cdn.com/content/v1/5cf55dd567d6ba0001de8755/1646094662362-LHCBQOM9THWM4PPLIZYQ/CB2D5B39-DE6B-4032-8F94-75182E36336C.jpg"
+      },
+      {
+        "dishName": "Pan-Fried Noodles",
+        "price": 10.5,
+        "image": "https://lh6.googleusercontent.com/DeHsaiZNjMgQ7KOMqu5BzSteUsVKf0obfPMqDtG16slGzEw397kdedJ9QB-6bZfMUQoLoYzvX0FLnzdJfKt8dxUOxd9J35c07xxJF6q1s6isM1YyiJOMj7nRERhbiXg8qQ96ZB6w=s0"
+      }
+    ],
+    "image": "https://img.liven.com.au/u/d/din-tai-fung/l/8CW2VHR1V.png",
+    "storeId": 74
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Sunset Bistro",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Strawberry-glazed Quail Skewers",
+        "price": 16.99,
+        "image": "https://i.pinimg.com/originals/98/96/aa/9896aafa94b8f60ed1bd24d3710eb173.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken",
+        "price": 14.95,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2020/02/kung-pao-chicken-1-1024x1536.jpg"
+      },
+      {
+        "dishName": "Pan-seared Dumplings (Pork & Veg)",
+        "price": 12.5,
+        "image": "https://video-images.vice.com/articles/631a4ef6863d22009b9352d5/lede/1662668664589-erics-dumplings-recipe.jpeg?image-resize-opts=Y3JvcD0xeHc6MC44NDI3eGg7MHh3LDAuMDM3MnhoJnJlc2l6ZT0xMjAwOiomcmVzaXplPTEyMDA6Kg"
+      },
+      {
+        "dishName": "Spicy Shrimp Stir Fry",
+        "price": 18.99,
+        "image": "https://thegourmetcookbook.com/wp-content/uploads/2023/04/Spicy-Garlic-Shrimp-Stir-Fry-Recipe-1680623155913.jpg"
+      },
+      {
+        "dishName": "Edamame Gyoza (Boiled Edamame in wonton wrapper)",
+        "price": 9.95,
+        "image": "https://www.summfoods.com/wp-content/uploads/2022/01/edamame-gyoza-bowl-on-wood-cropped-final-e1647889000319.jpg"
+      },
+      {
+        "dishName": "Thai Basil Beef Wrap (beef, Thai basil, lettuce, rice noodle, peanut sauce)",
+        "price": 13.5,
+        "image": "https://www.thespruceeats.com/thmb/3nJMMFCs61K_kQSABMybZeiHI-g=/960x0/filters:no_upscale():max_bytes(150000):strip_icc()/thailettucewrapswithbasil-57bb4df45f9b58cdfd2668e1.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/0a/b0/e4/0ab0e4074ab0ff3d90d3cec468b0a241.png",
+    "storeId": 75
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Wok This Way",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Orange-glazed Duck Skewers",
+        "price": 16.99,
+        "image": "https://www.gressinghamduck.co.uk/wp-content/uploads/2019/08/Honey-and-Orange-Glazed-Duck-Breast-3-1049x590.jpg"
+      },
+      {
+        "dishName": "Spicy Edamame Dumplings",
+        "price": 8.99,
+        "image": "https://cmx.weightwatchers.com/assets-proxy/weight-watchers/image/upload/t_WINE_EXTRALARGE/xl9n95amtqjlpxrtzzeq.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken Wings",
+        "price": 12.49,
+        "image": "https://www.chilesandsmoke.com/wp-content/uploads/2022/05/Kung-Pao-Wings_OTFC_Featured.jpg"
+      },
+      {
+        "dishName": "Pan-seared Salmon with Miso Glaze",
+        "price": 19.95,
+        "image": "https://tiffycooks.com/wp-content/uploads/2022/10/8DD66941-6C69-4DA5-9362-B51B7AAD0616-scaled.jpg"
+      },
+      {
+        "dishName": "Japanese-style Teriyaki Beef Skewers",
+        "price": 14.99,
+        "image": "https://therecipecritic.com/wp-content/uploads/2018/06/beef-teriyaki-skewers-4.jpg"
+      }
+    ],
+    "image": "https://as2.ftcdn.net/v2/jpg/05/02/53/91/1000_F_502539156_M9E4sa2thZ5isPjGuIGEX7qmDP8vI36R.jpg",
+    "storeId": 76
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Bella Vita Ristorante",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Meatballs With Sauce",
+        "price": 8.99,
+        "image": "https://www.jocooks.com/wp-content/uploads/2012/11/italian-meatballs-1-2-1.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 12.95,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 6.5,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/07/bruschetta-2.jpg"
+      },
+      {
+        "dishName": "Garlic Shrimp Linguine",
+        "price": 16.99,
+        "image": "https://media.chefdehome.com/740/0/0/shrimp-scampi/garlic-shrimp-scampi-linguine.jpg"
+      },
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 14.95,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4.jpg"
+      }
+    ],
+    "image": "https://dev.gastrocms.ch/images/data/3/Jul-2017/graph_logo.png",
+    "storeId": 77
+  },
+  {
+    "cityName": "Seattle",
+    "storeName": "The Cozy Corner Bistro",
+    "category": "Cafes & Bakeries",
+    "products": [
+      {
+        "dishName": "Fines Herbes-rubbed Turkey Salad",
+        "price": 12.99,
+        "image": "https://thumbs.dreamstime.com/z/spiced-rubbed-turkey-breast-salad-southwest-sliced-roasted-tenderloins-creamy-avocado-dressing-52670978.jpg"
+      },
+      {
+        "dishName": "Grilled Panini Sandwich",
+        "price": 9.99,
+        "image": "https://weekendatthecottage.com/wp-content/uploads/2017/08/CapresePanini7.jpg"
+      },
+      {
+        "dishName": "Quiche of the Day: Spinach & Feta",
+        "price": 10.49,
+        "image": "https://artofnaturalliving.com/wp-content/uploads/2022/08/Spinach_Feta_Quiche_02-copy.jpg"
+      },
+      {
+        "dishName": "Roasted Veggie Wrap",
+        "price": 8.99,
+        "image": "https://www.hiddenvalley.com/wp-content/uploads/2016/04/HVR_Roasted_Veggie_Wrap_AF.jpg"
+      },
+      {
+        "dishName": "French Onion Soup",
+        "price": 7.99,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2021/12/Classic-French-Onion-Soup-2-scaled.jpg"
+      },
+      {
+        "dishName": "Side Salad with Balsamic Vinaigrette",
+        "price": 6.99,
+        "image": "http://www.andiemitchell.com/wp-content/uploads/2019/05/everyday_house_salad_recipe-1-2.jpg"
+      }
+    ],
+    "image": "https://cozycornermv.com/wp-content/uploads/2023/11/logo-wo-bg-400x400-1.png",
+    "storeId": 78
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Aussie Bites",
+    "category": "Australian Grill House",
+    "products": [
+      {
+        "dishName": "Grilled Kangaroo Steak",
+        "price": 32.99,
+        "image": "https://ohmydish.com/wp-content/uploads/2015/12/Kangaroo-steak.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Barramundi",
+        "price": 29.95,
+        "image": "https://www.between2kitchens.com/wp-content/uploads/2022/03/Pan-fried-Barramundi-fish-fillets-with-Seaweed-butter-sauce-1-of-1.jpg"
+      },
+      {
+        "dishName": "Australian Wagyu Beef Rump",
+        "price": 45,
+        "image": "https://eatersmarket.sg/wp-content/uploads/2023/02/Wagyu-Beef-Rump-Shabu-Shabu-MS-4-5-1.jpg"
+      },
+      {
+        "dishName": "Bush Tucker Salad",
+        "price": 18.95,
+        "image": "http://static1.squarespace.com/static/58757c89e4fcb509a51c4c68/587582e3b3db2b3e1eca19bb/598ed86315d5db6d7e34e4ef/1503896036611/IMG_0899.JPG?format=1500w"
+      },
+      {
+        "dishName": "Lamb Chops with Mint Salsa",
+        "price": 24.99,
+        "image": "https://www.saveur.com/uploads/2019/06/07/AO5ZPT2DOASNNW7JGLUWTNTQTM.jpg?auto=webp"
+      }
+    ],
+    "image": "https://images.squarespace-cdn.com/content/v1/57f548bdbe6594103eb49184/1559239535758-JJ6O9NSO1EHJKDWZIB3S/Labels_001.jpg",
+    "storeId": 79
+  },
+  {
+    "cityName": "Caracas",
+    "storeName": "La Isla de los Sabores",
+    "category": "Food/Café",
+    "products": [
+      {
+        "dishName": "Reina Pepiada",
+        "price": 8.99,
+        "image": "https://blog.amigofoods.com/wp-content/uploads/2023/05/reina-pepiada-1024x683.jpg"
+      },
+      {
+        "dishName": "Perico con Huevo Frito",
+        "price": 10.5,
+        "image": "https://www.delishdlites.com/wp-content/uploads/2019/12/DSC_0649.jpg"
+      },
+      {
+        "dishName": "Cachapas de Queso",
+        "price": 7.95,
+        "image": "https://www.pequerecetas.com/wp-content/uploads/2021/06/cachapa-receta-venezolana.jpg"
+      },
+      {
+        "dishName": "Tallarin Verde de Pollo",
+        "price": 12.75,
+        "image": "https://www.comidasperuanas.vip/wp-content/uploads/2020/05/tallarines-verdes-con-pollo-9-2048x1152.jpg"
+      },
+      {
+        "dishName": "Carré de Pabellón",
+        "price": 14.25,
+        "image": "https://i0.wp.com/spicebreeze.com/wp-content/uploads/2023/01/Venezuelan-Pabellon-Criollo.png"
+      },
+      {
+        "dishName": "Chicharrón con Frijoles Negros",
+        "price": 15.5,
+        "image": "https://www.cocinavital.mx/wp-content/uploads/2019/08/frijoles-negros-con-carne-de-cerdo.jpg"
+      }
+    ],
+    "image": "https://espanol.cgtn.com/news/2023-04-04/1643045773563465730/afab39aa-c2f2-41e7-95b3-01dd94dbef00.png",
+    "storeId": 80
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Moe's Deli",
+    "category": "American",
+    "products": [
+      {
+        "dishName": "Rye And Turkey Pie",
+        "price": 12.99,
+        "image": "https://www.momontimeout.com/wp-content/uploads/2022/11/leftover-turkey-pot-pie.jpeg"
+      },
+      {
+        "dishName": "Crispy Chicken Wings",
+        "price": 9.99,
+        "image": "https://www.thecountrycook.net/wp-content/uploads/2023/05/thumbnail-Crispy-Oven-Baked-Chicken-Wings-scaled.jpg"
+      },
+      {
+        "dishName": "New York Style Cheesecake",
+        "price": 8.99,
+        "image": "https://bakerbynature.com/wp-content/uploads/2015/05/IMG_1699-2-2.jpg"
+      },
+      {
+        "dishName": "BLT Sandwich",
+        "price": 10.99,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/07/BLT-Sandwich-Recipe-4.jpg"
+      },
+      {
+        "dishName": "Creamy Coleslaw",
+        "price": 3.99,
+        "image": "https://southerndiscourse.com/wp-content/uploads/2022/09/southern-creamy-cole-slaw-celery-seed-scaled.jpg"
+      },
+      {
+        "dishName": "Baked Potato Soup",
+        "price": 7.49,
+        "image": "https://www.skinnytaste.com/wp-content/uploads/2016/08/Baked-Potato-Soup-5.jpg"
+      }
+    ],
+    "image": "https://rehobothfoodie.com/wp-content/uploads/2019/04/moes-LOGOcrenh.jpg",
+    "storeId": 81
+  },
+  {
+    "cityName": "Santa Fe",
+    "storeName": "Moonlight Noodle Co.",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Salty Buddhist Stew",
+        "price": 14.95,
+        "image": "https://cook.fnr.sndimg.com/content/dam/images/cook/fullset/2013/2/14/0/CC_bhide-buddhist-vegetarian-stew-recipe_s4x3.jpg.rend.hgtvcom.826.620.suffix/1360859740721.jpeg"
+      },
+      {
+        "dishName": "Spicy Szechuan Wontons",
+        "price": 12.5,
+        "image": "https://goodoldvegan.com/wp-content/uploads/2021/01/Sichuan-Spicy-Wontons-in-Sichuan-Garlic-Chilli-Oil.jpg"
+      },
+      {
+        "dishName": "K-Town BBQ Tacos",
+        "price": 16.25,
+        "image": "https://media-cdn.grubhub.com/image/upload/d_search:browse-images:default.jpg/w_1200,q_auto:low,fl_lossy,dpr_2.0,c_fill,f_auto,h_800,g_auto/q3qzvkkryro1c9nsfrgb"
+      },
+      {
+        "dishName": "Vietnamese Banh Mi Sandwich",
+        "price": 10.75,
+        "image": "http://cdn.shopify.com/s/files/1/0624/6583/5262/articles/Vietnamese_Grilled_Pork_Banh_Mi_Sandwich.jpg?v=1676358767"
+      },
+      {
+        "dishName": "Edamame Dumplings",
+        "price": 8.95,
+        "image": "https://whatshouldimakefor.com/wp-content/uploads/2017/04/cropped-Edamame-Dumplings.jpg"
+      },
+      {
+        "dishName": "Kung Pao Chicken Stir Fry",
+        "price": 13.5,
+        "image": "https://cafedelites.com/wp-content/uploads/2018/04/Best-Kung-Pao-Chicken-IMAGE-2.jpg"
+      },
+      {
+        "dishName": "Thai Green Curry Soup",
+        "price": 11.25,
+        "image": "https://playswellwithbutter.com/wp-content/uploads/2021/02/Thai-Green-Curry-with-Chicken-Vegetables-14.jpg"
+      }
+    ],
+    "image": "https://www.nicepng.com/png/detail/122-1225782_noodles-company-logo-noodles-co.png",
+    "storeId": 82
+  },
+  {
+    "cityName": "Tel Aviv",
+    "storeName": "Yam Yam",
+    "category": "Middle Eastern",
+    "products": [
+      {
+        "dishName": "Classic Hummus",
+        "price": 6.99,
+        "image": "https://laurenslatest.com/wp-content/uploads/2019/01/Hummus-Recipe-3.jpg"
+      },
+      {
+        "dishName": "Spicy Roasted Red Pepper Hummus",
+        "price": 7.49,
+        "image": "https://thedeliciousplate.com/wp-content/uploads/2018/04/IMG_1105.jpg"
+      },
+      {
+        "dishName": "Roasted Garlic and Pine Nut Hummus",
+        "price": 8.29,
+        "image": "https://www.apinchofhealthy.com/wp-content/uploads/2014/07/Roasted-garlic-hummus-closeup.jpg"
+      },
+      {
+        "dishName": "Chickpea-Free Black Bean Hummus",
+        "price": 7.99,
+        "image": "https://feelgoodfoodie.net/wp-content/uploads/2022/04/Roasted-Garlic-Hummus-10.jpg"
+      },
+      {
+        "dishName": "Lemon Rosemary Hummus with Pita Chips",
+        "price": 9.49,
+        "image": "https://i2.wp.com/sliceofhoney.com/wp-content/uploads/2019/05/Lemmon-Hummus-with-Rosemary-Pita-Chips-www.sliceofhoney.com_.jpg?fit=735%2C1102"
+      },
+      {
+        "dishName": "Spinach and Feta Stuffed Portobello Mushroom Burgers (V)",
+        "price": 10.99,
+        "image": "https://www.eatingwell.com/thmb/Ii0uaoF7jfC988m09jtWRkEQRDY=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/7715839-9f1154cd90c54acaa6126af96bf885b2.jpg"
+      }
+    ],
+    "image": "https://as1.ftcdn.net/v2/jpg/07/14/27/58/1000_F_714275804_Vce9kHfsSQWK1t4NntE2wQeH8pOnl30I.jpg",
+    "storeId": 83
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "Bella Vita",
+    "category": "Italian Restaurant",
+    "products": [
+      {
+        "dishName": "Tiramisù",
+        "price": 7.95,
+        "image": "https://littlesunnykitchen.com/wp-content/uploads/2021/01/Easy-Tiramisu-Recipe-2.jpg"
+      },
+      {
+        "dishName": "Spaghetti Carbonara",
+        "price": 14.99,
+        "image": "http://foodwhirl.com/wp-content/uploads/2017/02/spaghetti-carbonara-insta.jpg"
+      },
+      {
+        "dishName": "Bruschetta con Tomate e Basilico",
+        "price": 8.5,
+        "image": "https://assets.unileversolutions.com/recipes-v2/252259.jpg"
+      },
+      {
+        "dishName": "Pollo alla Cacciatora",
+        "price": 16.95,
+        "image": "https://www.thepetitecook.com/wp-content/uploads/2022/05/pollo-alla-cacciatora.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 15.99,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Panino con Prosciutto e Mozzarella",
+        "price": 10.5,
+        "image": "https://saporetti.it/wp-content/uploads/2022/05/SAPO_MENU-16-of-20-Large.jpg"
+      },
+      {
+        "dishName": "Gelato di Pistacchio",
+        "price": 6.95,
+        "image": "https://www.lucake.it/wp-content/uploads/2022/09/gelato-al-pistacchio-fatto-in-casa.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 84
+  },
+  {
+    "cityName": "New York",
+    "storeName": "The Cozy Catch",
+    "category": "Seafood",
+    "products": [
+      {
+        "dishName": "Pan-Seared Cod",
+        "price": 19.95,
+        "image": "https://bakerbynature.com/wp-content/uploads/2016/08/untitled-28-of-35.jpg"
+      },
+      {
+        "dishName": "Grilled Shrimp Skewers",
+        "price": 16.99,
+        "image": "https://www.servedfromscratch.com/wp-content/uploads/2018/05/IMG_1046.jpg"
+      },
+      {
+        "dishName": "Crab and Avocado Salad",
+        "price": 24.95,
+        "image": "https://www.foodfaithfitness.com/wp-content/uploads/2020/04/Crab-Avocado-Salad-image.jpg"
+      },
+      {
+        "dishName": "Peach-glazed Salmon Skewers",
+        "price": 22.49,
+        "image": "https://i.pinimg.com/originals/0b/b3/ec/0bb3ec241eb9df08ae67367f7624594c.jpg"
+      },
+      {
+        "dishName": "Steamed Mussels",
+        "price": 14.99,
+        "image": "https://www.thespruceeats.com/thmb/yDDtLzQ-OKzh50bB3eQFpNvy9CU=/4048x2696/filters:fill(auto,1)/steamed-mussels-white-wine-recipe-995527-hero-01-5c7d663446e0fb00018bd861.jpg"
+      },
+      {
+        "dishName": "Lobster Roll",
+        "price": 34.95,
+        "image": "https://tastefullygrace.com/wp-content/uploads/2023/08/Lobster-Roll-Recipe-1-scaled.jpg"
+      },
+      {
+        "dishName": "Fish and Chips",
+        "price": 18.49,
+        "image": "https://www.thespruceeats.com/thmb/uALIO4N-VCYA5SXIguM_9sJfEnk=/3606x2352/filters:fill(auto,1)/IMG_5442-58b427d35f9b586046d8dfa1.JPG"
+      }
+    ],
+    "image": "https://images-platform.99static.com/9s563IyChTuCI12V8wgCAFxpf9U=/0x0:962x962/fit-in/500x500/projects-files/110/11032/1103246/534b4e12-1d1a-4b5a-ab70-d3931b7a358c.png",
+    "storeId": 85
+  },
+  {
+    "cityName": "New Orleans",
+    "storeName": "Boudreaux's Cafe",
+    "category": "French Bistro",
+    "products": [
+      {
+        "dishName": "Cavalo Pie",
+        "price": 18.95,
+        "image": "https://i.pinimg.com/736x/66/26/e2/6626e283ffac6041ffcef90abf3f9b76--rustic-dinnerware-casual-dinnerware.jpg"
+      },
+      {
+        "dishName": "Muffuletta Sandwich",
+        "price": 14.5,
+        "image": "https://www.oliviascuisine.com/wp-content/uploads/2020/08/muffuletta-1024x1536.jpg"
+      },
+      {
+        "dishName": "Beignets",
+        "price": 6,
+        "image": "https://www.thespruceeats.com/thmb/959h4sihuuqU9Wv_RMzBtYz_Seg=/4301x2864/filters:fill(auto,1)/beignets-recipe-1375200-hero-01-2c32f40109f34599aa067e7301a46936.jpg"
+      },
+      {
+        "dishName": "French Onion Soup",
+        "price": 7.95,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2021/12/Classic-French-Onion-Soup-2-scaled.jpg"
+      },
+      {
+        "dishName": "Boudin Balls",
+        "price": 12.5,
+        "image": "https://cdn.apartmenttherapy.info/image/upload/f_auto,q_auto:eco,c_fill,g_auto,w_1500,ar_3:2/k%2FPhoto%2FRecipes%2F2023-02-Boudin-Balls%2FBoudin_Balls-2"
+      },
+      {
+        "dishName": "Jambalaya",
+        "price": 16,
+        "image": "https://bellyfull.net/wp-content/uploads/2021/02/Jambalaya-blog-1152x1536.jpg"
+      }
+    ],
+    "image": "https://patch.com/img/cdn/users/534202/2012/02/raw/94d3495b85f95f0ca8c18b925c411abf.jpg",
+    "storeId": 86
+  },
+  {
+    "cityName": "Barcelona",
+    "storeName": "La Casa del Mar",
+    "category": "Seafood",
+    "products": [
+      {
+        "dishName": "Paella de Marisco",
+        "price": 24.99,
+        "image": "http://www.daringgourmet.com/wp-content/uploads/2017/03/Seafood-Paella-10.jpg"
+      },
+      {
+        "dishName": "Gambas al Ajillo",
+        "price": 10.95,
+        "image": "https://www.carolinescooking.com/wp-content/uploads/2021/02/gambas-al-ajillo-garlic-shrimp-featured-pic-sq.jpg"
+      },
+      {
+        "dishName": "Pulpo a la Gallega",
+        "price": 12.5,
+        "image": "https://www.tastingtable.com/img/gallery/pulpo-a-la-gallega-galicias-delectable-octopus-dish/l-intro-1670432846.jpg"
+      },
+      {
+        "dishName": "Croquetas de Pescado",
+        "price": 8.95,
+        "image": "https://laroussecocina.mx/wp-content/uploads/2023/03/CROQUETA_1080X1080.jpg"
+      },
+      {
+        "dishName": "Tortilla de Merluza",
+        "price": 9.25,
+        "image": "https://lacocinadefrabisa.lavozdegalicia.es/wp-content/uploads/2015/07/tortilla-merluza-3.jpg"
+      },
+      {
+        "dishName": "Salsa Romesco con Pan Crujiente",
+        "price": 6.99,
+        "image": "https://static1.abc.es/media/bienestar/2022/02/24/alcachofa-crujiente-3-kV3F--620x349@abc.jpg"
+      }
+    ],
+    "image": "https://cozumelvisitorsguide.com/wp-content/uploads/2020/03/img_hotel_logo_casa_del_mar.jpg",
+    "storeId": 87
+  },
+  {
+    "cityName": "Melbourne",
+    "storeName": "Kanga's Bistro",
+    "category": "Fine Dining",
+    "products": [
+      {
+        "dishName": "Pan-Seared Kangaroo Loin with Radicchio Reduction",
+        "price": 45.99,
+        "image": "https://img.taste.com.au/WjWuHNAp/taste/2016/11/seared-kangaroo-with-raspberry-glaze-78221-1.jpeg"
+      },
+      {
+        "dishName": "Radicchio and Feta Salad with Grilled Kangaroo Skewers",
+        "price": 32.95,
+        "image": "https://familystylefood.com/wp-content/uploads/2023/01/cropped-Radicchio-Salad-Macro.jpg"
+      },
+      {
+        "dishName": "Kangaroo and Mushroom Risotto with Radicchio Infused Oil",
+        "price": 38.99,
+        "image": "https://nourishedkitchen.com/wp-content/uploads/2021/12/wild-mushroom-risotto-post.jpg"
+      },
+      {
+        "dishName": "Radicchio-Wrapped Kangaroo Tenderloin with Roasted Vegetables",
+        "price": 49.95,
+        "image": "https://i.pinimg.com/originals/33/30/c5/3330c5d8c94822df86e5ae8ea08830de.jpg"
+      },
+      {
+        "dishName": "Kangaroo and Radicchio Tacos with Spicy Slaw",
+        "price": 29.99,
+        "image": "https://d1e3z2jco40k3v.cloudfront.net/-/media/clubhouse-for-chef/recipes/c2c-recipe-images-2021/thomas-jnr-kagoro_recipe_mobile.png?rev=a3dbf3e95621489da0d832429c8fc06c&vd=20211103T190257Z&hash=22B1C5E6EDAA409A2D687D2CF39FE5FD"
+      },
+      {
+        "dishName": "Grilled Kangaroo Chops with Roasted Radicchio and Polenta",
+        "price": 42.95,
+        "image": "https://img.delicious.com.au/gVlHgnn5/w1200/del/2015/10/chargrilled-kangaroo-with-beetroot-and-radicchio-14109-1.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/298228367_123425227094171_1954920293302329471_n.jpg?_nc_cat=104&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=FDgn8p3bE_IQ7kNvgGuYLLc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=AGbF0vvtijijYIHRK3oHGAm&oh=00_AYC4RuCDKedcdFgpF0TMLSbadtseJe35bTyhNlaKJHHozA&oe=675D32A8",
+    "storeId": 88
+  },
+  {
+    "cityName": "Rome",
+    "storeName": "La Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Spaghetti Aglio e Olio",
+        "price": 8.95,
+        "image": "https://cdn.apartmenttherapy.info/image/fetch/f_auto,q_auto:eco,c_fill,g_auto,w_1460/https://storage.googleapis.com/gen-atmedia/3/2018/07/e77cb676a9408994b6b07b673d46d17bdbf8814c.jpeg"
+      },
+      {
+        "dishName": "Pasta Carbonara",
+        "price": 12.5,
+        "image": "https://therecipecritic.com/wp-content/uploads/2018/04/pasta-carbonara-15.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 14,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Bruschetta con Pomodoro e Basilico",
+        "price": 7.2,
+        "image": "https://perfettissimo.net/wp-content/uploads/2021/05/Bruschette-al-pomodoro-scaled.jpeg"
+      },
+      {
+        "dishName": "Risotto alla Milanese",
+        "price": 16.5,
+        "image": "https://i.pinimg.com/originals/a1/b9/36/a1b9367f8eb4525534fd8b24b2b70843.jpg"
+      },
+      {
+        "dishName": "Pollo al Pollo",
+        "price": 10.95,
+        "image": "https://cocinateelmundo.com/wp-content/uploads/2019/11/chicken-farm-4213949_1280.jpg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 89
+  },
+  {
+    "cityName": "Paris",
+    "storeName": "Le Coeur de la Vie",
+    "category": "French Cuisine",
+    "products": [
+      {
+        "dishName": "Rabbit Steak au Poivre",
+        "price": 32.5,
+        "image": "https://www.rabbitandwolves.com/wp-content/uploads/2019/12/Vegan-Portobello-Steak-Au-Poivre0520.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Scallops with Garlic Butter",
+        "price": 25,
+        "image": "https://www.saltandlavender.com/wp-content/uploads/2020/03/pan-seared-scallops-cream-sauce-1-720x1063.jpg"
+      },
+      {
+        "dishName": "Crispy Duck Confit with Cherry Compote",
+        "price": 28.75,
+        "image": "https://img.delicious.com.au/99T99RcI/w1200/del/2015/10/duck-confit-with-sour-cherry-sauce-and-apple-fennel-and-walnut-salad-12213-1.jpg"
+      },
+      {
+        "dishName": "Grilled Filet Mignon with Roasted Vegetables",
+        "price": 35.95,
+        "image": "https://bigoven-res.cloudinary.com/image/upload/t_recipe-1280/filet-mignon-roast-with-roaste-f52f16.jpg"
+      },
+      {
+        "dishName": "Seared Salmon with Lemon Dill Sauce",
+        "price": 29.5,
+        "image": "https://skinnyms.com/wp-content/uploads/2021/09/Pan-Seared-Salmon-with-Creamy-Lemon-Dill-Sauce-5-Go-1200x1200.jpg"
+      },
+      {
+        "dishName": "Rabbit Steak Tartare with Truffle Oil",
+        "price": 30.25,
+        "image": "https://www.trufflehill.com.au/wp-content/uploads/2023/06/Truffled-Stake-Tartare.webp"
+      },
+      {
+        "dishName": "Baked Camembert with Fresh Fruits and Nuts",
+        "price": 18,
+        "image": "https://girlheartfood.com/wp-content/uploads/2022/06/Baked-Camembert.jpg"
+      }
+    ],
+    "image": "https://img.src.ca/2014/11/25/1250x703/141125_3c6hy_aucoeurdelavie_logo_sn1250.jpg",
+    "storeId": 90
+  },
+  {
+    "cityName": "Arendal",
+    "storeName": "Taverna Marenina",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Bruschetta con Pomodoro",
+        "price": 8.9,
+        "image": "https://data.thefeedfeed.com/static/2020/11/13/16052598335fae5239390f4.jpg"
+      },
+      {
+        "dishName": "Spaghetti Carbonara",
+        "price": 16.5,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2023/01/Carbonara_6a.jpg"
+      },
+      {
+        "dishName": "Risotto alla Tartufata",
+        "price": 20.2,
+        "image": "https://www.cucchiaio.it/content/dam/cucchiaio/it/ricette/2024/03/risotto-alla-salsa-tartufata/Risotto%20con%20salsa%20al%20tartufo_b_orizz.jpg"
+      },
+      {
+        "dishName": "Pollo alla Cacciatora",
+        "price": 18.9,
+        "image": "https://www.thepetitecook.com/wp-content/uploads/2022/05/pollo-alla-cacciatora.jpg"
+      },
+      {
+        "dishName": "Sammi Rice Syrup Soup",
+        "price": 12.1,
+        "image": "https://images.squarespace-cdn.com/content/v1/5c807240797f74235553141e/8b24602a-18d8-43e1-83c4-9edb4a74e107/FullSizeRender+6.jpg?format=1000w"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 15.8,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/e7/ba/4d/e7ba4dede4c39d903e9da13d34f58d9f.png",
+    "storeId": 91
+  },
+  {
+    "cityName": "Bangalore",
+    "storeName": "Saffron Spice",
+    "category": "Indian",
+    "products": [
+      {
+        "dishName": "Andhra Spinach Soup",
+        "price": 6.5,
+        "image": "https://www.cookshideout.com/wp-content/uploads/2006/10/Palakura-Pulusu5S-768x1156.jpg"
+      },
+      {
+        "dishName": "Chicken Tikka Masala",
+        "price": 14.99,
+        "image": "https://149433378.v2.pressablecdn.com/wp-content/uploads/2020/08/Chicken-Tikka-Masala-scaled.jpg"
+      },
+      {
+        "dishName": "Sag Aloo",
+        "price": 8.95,
+        "image": "https://realfood.tesco.com/media/images/RFO-1400x919-Saag-aloo-f16c3a49-d1a4-49b5-aaab-10c5c47921e9-0-1400x919.jpg"
+      },
+      {
+        "dishName": "Biryani Rice Bowl",
+        "price": 12,
+        "image": "https://cdn.shortpixel.ai/client/q_lossy,ret_img,w_1290/https://norecipes.com/wp-content/uploads/2017/05/chicken-biryani-12-1290x1934.jpg"
+      },
+      {
+        "dishName": "Raj Kachori",
+        "price": 9.25,
+        "image": "https://i2.wp.com/www.vegrecipesofindia.com/wp-content/uploads/2018/03/raj-kachori-recipe.jpg"
+      },
+      {
+        "dishName": "Mattar Paneer",
+        "price": 13.5,
+        "image": "http://recipes.timesofindia.com/photo/53251884.cms"
+      }
+    ],
+    "image": "https://www.logolynx.com/images/logolynx/08/08a53c936308700fc310c4038ef134ad.jpeg",
+    "storeId": 92
+  },
+  {
+    "cityName": "Paris",
+    "storeName": "Bistro Bliss",
+    "category": "Fast Food",
+    "products": [
+      {
+        "dishName": "French Fries with Sausages (Small)",
+        "price": 8.99,
+        "image": "https://thumbs.dreamstime.com/b/eggs-french-fries-small-sausages-typical-spanish-dish-47623983.jpg"
+      },
+      {
+        "dishName": "French Fries with Sausages (Medium)",
+        "price": 11.99,
+        "image": "https://thumbs.dreamstime.com/z/delicious-dish-french-fries-fried-eggs-sausages-delicious-dish-french-fries-fried-eggs-four-sausages-close-279845154.jpg"
+      },
+      {
+        "dishName": "French Fries with Sausages (Large)",
+        "price": 14.99,
+        "image": "https://st.depositphotos.com/1003814/2079/i/950/depositphotos_20795541-stock-photo-grilled-sausages-french-fries-and.jpg"
+      },
+      {
+        "dishName": "Sausage Platter",
+        "price": 9.99,
+        "image": "https://s23209.pcdn.co/wp-content/uploads/2018/09/Grilled-Sausages-Peppers-and-PotatoesIMG_5723.jpg"
+      },
+      {
+        "dishName": "Cheese Fries",
+        "price": 7.49,
+        "image": "https://easyappetizers.com/wp-content/uploads/2022/01/cheese-fries-social-scaled.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=A0yGDize6-vJUWYNFRrvh56&oh=00_AYBSIFzqiBv5Oquu_iJVqi_5mEyoXPz4iNc2hcfrf11zkA&oe=675D1821",
+    "storeId": 93
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Tasty Bites Cafe",
+    "category": "Cafes & Bakeries",
+    "products": [
+      {
+        "dishName": "Coffee and Pastry",
+        "price": 4.5,
+        "image": "https://get.pxhere.com/photo/food-cuisine-coffee-cup-dish-pastry-hand-finger-croissant-breakfast-cup-baked-goods-tableware-espresso-ingredient-dessert-doughnut-1499077.jpg"
+      },
+      {
+        "dishName": "Eggs Benedict",
+        "price": 14.99,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/02/eggs-benedict-3.jpg"
+      },
+      {
+        "dishName": "Avocado Toast",
+        "price": 12,
+        "image": "https://www.jessicagavin.com/wp-content/uploads/2020/07/avocado-toast-20.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken Salad",
+        "price": 15.5,
+        "image": "https://gimmesomegrilling.com/wp-content/uploads/2021/05/Grilled-Chicken-Salad-Recipe-Square.jpg"
+      },
+      {
+        "dishName": "Custard Apples Daikon Pie",
+        "price": 10.99,
+        "image": "https://thefoodcharlatan.com/wp-content/uploads/2016/10/IMG_5715-600x900.jpg"
+      }
+    ],
+    "image": "https://dcassetcdn.com/design_img/500681/148570/148570_3650142_500681_image.png",
+    "storeId": 94
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Bistro Bliss",
+    "category": "Fine Dining",
+    "products": [
+      {
+        "dishName": "Pan-Seared Scallops with Garlic Butter Linguine",
+        "price": 42.99,
+        "image": "https://www.saltandlavender.com/wp-content/uploads/2020/03/pan-seared-scallops-cream-sauce-1-720x1063.jpg"
+      },
+      {
+        "dishName": "Grilled Lamb Chops with Rosemary and Lemon",
+        "price": 32.95,
+        "image": "https://simply-delicious-food.com/wp-content/uploads/2021/05/Garlic-rosemary-lamb-chops-1.jpg"
+      },
+      {
+        "dishName": "Colombo-crusted Venison with Roasted Vegetables",
+        "price": 45,
+        "image": "https://inspiredcuisine.ca/wp-content/uploads/2020/12/IMG_1040K3-1080x675.jpg"
+      },
+      {
+        "dishName": "Wild Mushroom Risotto with Truffle Oil",
+        "price": 38.99,
+        "image": "https://www.surlatable.com/dw/image/v2/BCJL_PRD/on/demandware.static/-/Sites-shop-slt-master-catalog-recipes/default/dw94916f41/images/large/REC-344007_Wild-Mushroom-Risotto-with-Truffle-Oil.jpg?sw=688&sh=680&sm=fit"
+      },
+      {
+        "dishName": "Seared Salmon with Citrus and Avocado Salad",
+        "price": 29.95,
+        "image": "https://i.pinimg.com/736x/3e/a2/93/3ea293d59108c4e9a6be923c54e6f17b.jpg"
+      },
+      {
+        "dishName": "Creamy Asparagus Soup with Crispy Prosciutto",
+        "price": 16.99,
+        "image": "https://blog.williams-sonoma.com/wp-content/uploads/2013/03/AsparagusPoachedEgg_1770.jpg"
+      }
+    ],
+    "image": "https://scontent-scl2-1.xx.fbcdn.net/v/t39.30808-6/347561706_560618442944720_7686147240245947881_n.jpg?_nc_cat=109&ccb=1-7&_nc_sid=6ee11a&_nc_ohc=8m6JbfmkxsIQ7kNvgFj6xtc&_nc_zt=23&_nc_ht=scontent-scl2-1.xx&_nc_gid=AvQGB7WrKzAhzVLHdX87qd4&oh=00_AYB0nrJ8-ntZUbRTXGBQYVqKHviYSNq_AQF8T_eOb6RzTA&oe=675D1821",
+    "storeId": 95
+  },
+  {
+    "cityName": "Edinburgh",
+    "storeName": "The Royal Diner",
+    "category": "British Pub Food",
+    "products": [
+      {
+        "dishName": "Scotch Egg Classic",
+        "price": 4.99,
+        "image": "https://www.thespruceeats.com/thmb/airB8Cf4BqT-TWeWJcsQHEf4YpE=/3000x2000/filters:fill(auto,1)/healthier-real-scotch-egg-recipe-435658-Hero_01-64c4a01d1f5947b69b83f21375ab4d2a.jpg"
+      },
+      {
+        "dishName": "Spicy Scotch Egg",
+        "price": 5.29,
+        "image": "https://www.billyparisi.com/wp-content/uploads/2023/04/scotch-eggs-3-1160x1160.jpg"
+      },
+      {
+        "dishName": "Eggs Benedict with Scotch Egg",
+        "price": 8.99,
+        "image": "https://s23209.pcdn.co/wp-content/uploads/2022/09/220602_DD_Eggs-Benedict_368-1200x1200-cropped.jpg"
+      },
+      {
+        "dishName": "Scotch Egg Platter (4 Eggs)",
+        "price": 14.99,
+        "image": "https://cdn.apartmenttherapy.info/image/upload/f_auto,q_auto:eco,c_fill,g_center,w_730,h_913/k/Photo/Recipes/2022-01_scotch-egg/2022-01-05_ATK-0996"
+      },
+      {
+        "dishName": "Crispy Bacon Scotch Egg",
+        "price": 5.49,
+        "image": "https://tagvault.org/wp-content/uploads/2024/01/Bacon-Scotch-Egg-Recipe-768x614.jpg"
+      },
+      {
+        "dishName": "Egg and Sausage Scotch Egg Wrap",
+        "price": 6.49,
+        "image": "https://www.jidlonacestach.cz/wp-content/uploads/2023/05/scotch-egg-scaled.jpg"
+      }
+    ],
+    "image": "https://www.theroyaldinervt.com/assets/royal-diner-logo.png",
+    "storeId": 96
+  },
+  {
+    "cityName": "Los Angeles",
+    "storeName": "The Fresh Bistro",
+    "category": "Healthy Food & Cafes",
+    "products": [
+      {
+        "dishName": "Mint-rubbed Beef Salad",
+        "price": 14.95,
+        "image": "https://www.marionskitchen.com/wp-content/uploads/2021/06/20170913_Thai-salad-9-1.jpeg"
+      },
+      {
+        "dishName": "Grilled Chicken Wrap",
+        "price": 12.5,
+        "image": "https://www.aspicyperspective.com/wp-content/uploads/2023/03/Easy-Grilled-Chicken-Wrap-Recipe-24.jpg"
+      },
+      {
+        "dishName": "Quinoa and Black Bean Bowl",
+        "price": 13.25,
+        "image": "https://www.eatingwell.com/thmb/CLV0ZHU_NMcm-OigfRbs_9ACLEs=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/4565089-13d53eaaf57f47869c5fe402a9b3e492.jpg"
+      },
+      {
+        "dishName": "Avocado Toast",
+        "price": 10.95,
+        "image": "http://static1.squarespace.com/static/60f9bc54b58d9f20a4dbc2c4/60fb3889d8f5e37d30bd806a/62a09f51abe961756420c839/1654701631660/IMG_4169a.JPG?format=1500w"
+      },
+      {
+        "dishName": "Spinach and Feta Stuffed Portobellos",
+        "price": 16.5,
+        "image": "https://recipefund.com/wp-content/uploads/jet-form-builder/f133c249d4a29961d2fd87ee9713e9c1/2023/04/Spinach-and-Feta-Stuffed-Portobello-Mushrooms-2-768x432.png"
+      },
+      {
+        "dishName": "Tomato and Mozzarella Salad",
+        "price": 11.25,
+        "image": "https://littlespicejar.com/wp-content/uploads/2019/07/Marinated-Mozzarella-Tomato-Salad-10-1.jpg"
+      }
+    ],
+    "image": "https://www.design-hero.com/wp-content/uploads/project-fresh-bistro-logo-color-1-768x197.png",
+    "storeId": 97
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Aussie Bites",
+    "category": "Australian",
+    "products": [
+      {
+        "dishName": "Kangaroo With Pineapple Sauce",
+        "price": 25.99,
+        "image": "http://k-roo.com.au/wp-content/uploads/2020/09/EG10_EP54_Kangaroo-with-Roasted-Capsicum-Salad-_MG_4226.jpg"
+      },
+      {
+        "dishName": "Grilled Steak with Roasted Vegetables",
+        "price": 18.5,
+        "image": "https://thewholecook.com/wp-content/uploads/2023/01/Steak-with-Roasted-Veggies-1.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Barramundi with Quinoa and Lemon",
+        "price": 22,
+        "image": "https://www.between2kitchens.com/wp-content/uploads/2022/03/Pan-fried-Barramundi-fish-fillets-with-Seaweed-butter-sauce-1-of-1.jpg"
+      },
+      {
+        "dishName": "Australian Lamb Chops with Garlic Mashed Potatoes",
+        "price": 19.95,
+        "image": "https://lh3.googleusercontent.com/wh8Tvyg3xd_Ra337w4IBFsYe65mp-Q0NI8dMc_kTKc_S_DGaFECTMeYLI7RQF1eD5ElTHpq3lnkXRFNT6f_nPg=w1200-h630-pp-rj-v1-e365"
+      },
+      {
+        "dishName": "Vegetable Stir Fry with Tofu and Noodles",
+        "price": 15.99,
+        "image": "https://i2.wp.com/munchmealsbyjanet.com/wp-content/uploads/2020/05/20200503_134128-01.jpeg?resize=1152%2C1536&ssl=1"
+      }
+    ],
+    "image": "https://images.squarespace-cdn.com/content/v1/57f548bdbe6594103eb49184/1559239535758-JJ6O9NSO1EHJKDWZIB3S/Labels_001.jpg",
+    "storeId": 98
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Aussie Bistro",
+    "category": "Meat Restaurant",
+    "products": [
+      {
+        "dishName": "Grilled Octopus with Lemon",
+        "price": 25.99,
+        "image": "https://media02.stockfood.com/largepreviews/NDIyNzcwOTYz/13637773-Grilled-octopus-with-lemon-slice.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Barramundi with Garlic Butter",
+        "price": 29.95,
+        "image": "https://www.between2kitchens.com/wp-content/uploads/2022/03/Pan-fried-Barramundi-fish-fillets-with-Seaweed-butter-sauce-1-of-1.jpg"
+      },
+      {
+        "dishName": "Rack of Lamb with Rosemary and Potatoes",
+        "price": 42.5,
+        "image": "https://www.recipetineats.com/wp-content/uploads/2020/12/Crumbed-rack-of-lamb_5.jpg?w=900"
+      },
+      {
+        "dishName": "Grilled Emu With Tomato Sauce (Special)",
+        "price": 19.99,
+        "image": "https://i.pinimg.com/736x/77/ff/2c/77ff2c3dac1ed74dc6e14692d85ac52a.jpg"
+      },
+      {
+        "dishName": "Roasted Duck Breast with Cherry Compote",
+        "price": 31.99,
+        "image": "https://bibleoftaste.files.wordpress.com/2022/08/duck-breast-cherry-sauce.jpg?w=1200"
+      },
+      {
+        "dishName": "Seared Tuna Steak with Soy-Ginger Sauce",
+        "price": 26.95,
+        "image": "https://i.pinimg.com/736x/94/69/22/9469226599fb4a36eff0f3874deb7dae.jpg"
+      },
+      {
+        "dishName": "Pan-Fried Pork Chops with Apple Cider Jus",
+        "price": 24.75,
+        "image": "https://cravinghomecooked.com/wp-content/uploads/2022/08/apple-cider-glazed-pork-chops-1-13-750x938.jpg"
+      }
+    ],
+    "image": "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/9b69b473944677.5c1aadf18216d.png",
+    "storeId": 99
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Burger King",
+    "category": "Fast Food",
+    "products": [
+      {
+        "dishName": "Cheeseburger",
+        "price": 6.99,
+        "image": "https://foodetccooks.com/wp-content/uploads/2017/02/IMG_7933.jpg"
+      },
+      {
+        "dishName": "Chicken Sandwich",
+        "price": 7.49,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/06/Chicken-Sandwich-7.jpg"
+      },
+      {
+        "dishName": "French Fries",
+        "price": 3.99,
+        "image": "https://www.momontimeout.com/wp-content/uploads/2021/05/oven-fries-square.jpeg"
+      },
+      {
+        "dishName": "Coca Cola",
+        "price": 2.5,
+        "image": "https://i5.walmartimages.com/asr/12a67f4e-5359-4598-a284-8d25680d2c94.ad146ae271a40fface3035aa70dd8746.jpeg?odnWidth=1000&odnHeight=1000&odnBg=ffffff"
+      },
+      {
+        "dishName": "Fruit Salad",
+        "price": 4.99,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2019/05/fruit-salad-4.jpg"
+      },
+      {
+        "dishName": "Chicken Nuggets (4pc)",
+        "price": 8.99,
+        "image": "https://www.momontimeout.com/wp-content/uploads/2021/02/chicken-nuggets-recipe-with-sauce-square.jpg"
+      }
+    ],
+    "image": "https://logos-world.net/wp-content/uploads/2020/04/Burger-King-Logo-1994-1999.png",
+    "storeId": 100
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Kanga's Grill",
+    "category": "Asian Fusion",
+    "products": [
+      {
+        "dishName": "Custard Apple-glazed Kangaroo Skewers",
+        "price": 29.95,
+        "image": "https://www.cookedandloved.com/wp-content/uploads/2012/05/kangaroo-skewers-pin.jpg"
+      },
+      {
+        "dishName": "Spicy Tamarillo Satay",
+        "price": 17.5,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/01/Spicy-Beef-Satay_EXPS_TOHCA21_63453_B12_16_3b.jpg"
+      },
+      {
+        "dishName": "Korean BBQ Pork Ribs",
+        "price": 24.99,
+        "image": "https://glebekitchen.com/wp-content/uploads/2018/04/koreanbraisedporkribsfront.jpg"
+      },
+      {
+        "dishName": "Green Papaya and Shrimp Salad",
+        "price": 19.95,
+        "image": "http://4.bp.blogspot.com/-jnuFEdBju1I/UBjIAWKDZ3I/AAAAAAAAFVU/FrXiHuaYK3w/s1600/IMG_8061.JPG"
+      },
+      {
+        "dishName": "Mango Sticky Rice with Coconut Ice Cream",
+        "price": 8.99,
+        "image": "https://www.denverlifemagazine.com/wp-content/uploads/2021/07/July-2021-Heaven-Creamery-Mango-Sticky-Rice-Recipe.jpg"
+      },
+      {
+        "dishName": "Japanese Teriyaki Chicken Skewers",
+        "price": 22.5,
+        "image": "https://sp-ao.shortpixel.ai/client/to_webp,q_glossy,ret_img/https://www.appetizeraddiction.com/wp-content/uploads/2020/07/teriyaki-chicken-skewers-pin-735x1103.jpg"
+      }
+    ],
+    "image": "https://www.underconsideration.com/brandnew/archives/kanga_logo.png",
+    "storeId": 101
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Sushi Tsunami",
+    "category": "Seafood",
+    "products": [
+      {
+        "dishName": "Tuna Sashimi",
+        "price": 15.99,
+        "image": "https://www.thespruceeats.com/thmb/ZOb4Q8I5-4dLA-fddV0wwIlmcRg=/2001x1501/filters:fill(auto,1)/454629837-58a4b2de5f9b58819cf851f5.jpg"
+      },
+      {
+        "dishName": "Salmon Nigiri",
+        "price": 12.95,
+        "image": "https://izzycooking.com/wp-content/uploads/2020/10/Salmon-Nigiri-2.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Roll",
+        "price": 14.5,
+        "image": "https://thewoodenskillet.com/wp-content/uploads/2023/06/spicy-tuna-roll-recipe-2.jpg"
+      },
+      {
+        "dishName": "Shrimp Tempura",
+        "price": 11.25,
+        "image": "https://simplyhomecooked.com/wp-content/uploads/2019/12/shrimp-tempura-recipe-8.jpg"
+      },
+      {
+        "dishName": "Tofu Miso Soup",
+        "price": 6.95,
+        "image": "https://flaevor.com/wp-content/uploads/2020/09/CrispyTofuMisoSoupRecipe-1.jpg"
+      }
+    ],
+    "image": "http://logopond.com/logos/91f413e316e435f7c634c180bca3cd8f.png",
+    "storeId": 102
+  },
+  {
+    "cityName": "Chicago",
+    "storeName": "Pitmaster's Paradise",
+    "category": "American",
+    "products": [
+      {
+        "dishName": "Barbecue Ribs (Full Rack)",
+        "price": 24.99,
+        "image": "https://thumbs.dreamstime.com/z/full-rack-bbq-ribs-mashed-potato-coleslaw-51265588.jpg"
+      },
+      {
+        "dishName": "Grilled Chicken Sandwich",
+        "price": 10.99,
+        "image": "https://www.apinchofhealthy.com/wp-content/uploads/2021/09/Close-up-side-shot-of-styled-sandwich-2.jpg"
+      },
+      {
+        "dishName": "Baked Beans",
+        "price": 5.49,
+        "image": "https://therecipecritic.com/wp-content/uploads/2018/07/worlds_best_baked_beans-1-of-1.jpg"
+      },
+      {
+        "dishName": "Coleslaw",
+        "price": 4.29,
+        "image": "https://dinnerthendessert.com/wp-content/uploads/2018/04/Cole-Slaw-2-1048x1572.jpg"
+      },
+      {
+        "dishName": "Mac & Cheese",
+        "price": 7.99,
+        "image": "https://www.thespruceeats.com/thmb/HP8-i7Gqx39wGB1fANmIirH6_og=/6048x4032/filters:fill(auto,1)/baked-macaroni-and-cheese-183780212-5892ac5b3df78caebcfa3bc9.jpg"
+      },
+      {
+        "dishName": "Garlic Bread",
+        "price": 6.49,
+        "image": "https://www.ambitiouskitchen.com/wp-content/uploads/2023/02/Garlic-Bread-4.jpg"
+      }
+    ],
+    "image": "https://mir-s3-cdn-cf.behance.net/project_modules/max_1200/6528f596761033.5eb57fd1dae47.jpg",
+    "storeId": 103
+  },
+  {
+    "cityName": "Caracas",
+    "storeName": "Arepas Fritas",
+    "category": "Latin American",
+    "products": [
+      {
+        "dishName": "Reina Pepiada",
+        "price": 10.99,
+        "image": "https://blog.amigofoods.com/wp-content/uploads/2023/05/reina-pepiada-1024x683.jpg"
+      },
+      {
+        "dishName": "Perico de Gallina",
+        "price": 12.5,
+        "image": "https://t1.uc.ltmcdn.com/es/posts/6/5/1/como_hacer_perico_venezolano_28156_orig.jpg"
+      },
+      {
+        "dishName": "La Venezolana",
+        "price": 9.95,
+        "image": "https://blog.amigofoods.com/wp-content/uploads/2020/11/venezuelan-pabellon-criollo.jpg"
+      },
+      {
+        "dishName": "Pabellón Criollo",
+        "price": 11.25,
+        "image": "https://blog.amigofoods.com/wp-content/uploads/2020/11/venezuelan-pabellon-criollo.jpg"
+      },
+      {
+        "dishName": "Arepita de Queso",
+        "price": 7.99,
+        "image": "https://arepasdelgringo.com/wp-content/uploads/2015/02/arepas_with_cheese_recipe.jpg"
+      },
+      {
+        "dishName": "Chicharrón",
+        "price": 8.5,
+        "image": "https://www.dominicancooking.com/wp-content/uploads/chicharrones-receta-DSC7906.jpg"
+      }
+    ],
+    "image": "https://www.laylita.com/recetas/wp-content/uploads/2023/03/Arepas-Fritas-rellenas.jpg",
+    "storeId": 104
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Tasty Bites",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Garlic Salad",
+        "price": 8.99,
+        "image": "https://www.theoriginaldish.com/wp-content/uploads/2020/12/Roasted-Garlic-Kale-Caesar-Salad-2-scaled.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 12.99,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Bruschetta",
+        "price": 6.99,
+        "image": "https://www.thespruceeats.com/thmb/DbS97y1KmR3N6YfGxy3JWAEt2yc=/3000x2000/filters:fill(auto,1)/how-to-make-bruschetta-2020459-hero-01-15950eb2b852461abc9cfbbf536382dd.jpg"
+      },
+      {
+        "dishName": "Fettuccine Alfredo",
+        "price": 10.99,
+        "image": "http://www.cookingclassy.com/wp-content/uploads/2012/12/light-fettucine-alfredo.jpg"
+      },
+      {
+        "dishName": "Caprese Salad",
+        "price": 9.49,
+        "image": "https://www.themediterraneandish.com/wp-content/uploads/2023/06/Caprese-Salad_7.jpg"
+      },
+      {
+        "dishName": "Chicken Parmesan",
+        "price": 14.99,
+        "image": "https://natashaskitchen.com/wp-content/uploads/2020/02/Chicken-Parmesan-Recipe-4-728x1092.jpg"
+      }
+    ],
+    "image": "https://cdn.shopify.com/s/files/1/0648/1454/7198/files/New_Tasty_Bite_Logo.png?height=628&pad_color=ffffff&v=1655492370&width=1200",
+    "storeId": 105
+  },
+  {
+    "cityName": "Sydney",
+    "storeName": "Terra Verde",
+    "category": "Modern Australian",
+    "products": [
+      {
+        "dishName": "Grilled Emu Chop with Choy Sum and Lemon Myrtle",
+        "price": 32.95,
+        "image": "https://www.chefspencil.com/wp-content/uploads/Ostrich-Steak-1.jpg"
+      },
+      {
+        "dishName": "Pan-Seared Emu Breast with Choy Sum Risotto and Wild Mushroom",
+        "price": 39.95,
+        "image": "https://d2uqlwridla7kt.cloudfront.net/recipe-media/recipe-9l1ch7bct/ac87s99l1chnonu/Seared%20Scallop%20Risotto%202%20(square).jpeg"
+      },
+      {
+        "dishName": "Emu and Choy Sum Stir-Fry with Szechuan Pepper and Chili Oil",
+        "price": 24.95,
+        "image": "https://thewanderlustkitchen.com/wp-content/uploads/2016/12/Sichuan-Tofu-Bok-Choy-Stir-Fry-3.jpg"
+      },
+      {
+        "dishName": "Choy Sum-Infused Emu Burger with Aioli and Pickled Slaw",
+        "price": 29.95,
+        "image": "https://hometoheather.com/wp-content/uploads/2015/06/meatloaf-burger-with-pickled-slaw-700x1050.jpg"
+      },
+      {
+        "dishName": "Emu Rump with Choy Sum Salsa and Crispy Plantain Chips",
+        "price": 34.95,
+        "image": "https://www.seriouseats.com/thmb/68uFEL8W1PQzjVR0nMEOs40en1c=/1500x0/filters:no_upscale():max_bytes(150000):strip_icc()/__opt__aboutcom__coeus__resources__content_migration__serious_eats__seriouseats.com__2021__01__20210105-fried-plantains-tim-chin-12-174f7b5f473548f6a828d7de588b0942.jpg"
+      },
+      {
+        "dishName": "Emu Tenderloin with Choy Sum-Butter Sauce and Garlic Mashed Potatoes",
+        "price": 44.95,
+        "image": "https://yejiskitchenstories.com/wp-content/uploads/2022/08/Easy_garlic_yu_choy_sum-1024x1536.jpg"
+      }
+    ],
+    "image": "https://terraverde-solutions.com/wp-content/uploads/2022/11/TerraVerde-Logo-2.png",
+    "storeId": 106
+  },
+  {
+    "cityName": "Denver",
+    "storeName": "Mia's Cozy Corner",
+    "category": "Bakery",
+    "products": [
+      {
+        "dishName": "Classic Ciabatta",
+        "price": 4.99,
+        "image": "https://thetinyfairy.com/wp-content/uploads/2020/06/img_7968-scaled.jpg"
+      },
+      {
+        "dishName": "Mia's Special Mountain Bread",
+        "price": 5.95,
+        "image": "https://www.miascucina.com/wp-content/uploads/2018/11/Toasted-Breadcrumb-Gremolata-Banner-1.jpg"
+      },
+      {
+        "dishName": "Artisan Focaccia",
+        "price": 6.49,
+        "image": "https://www.sidechef.com/recipe/f4aab28f-4f03-450c-b2c1-ff21deb9bfb6.jpeg"
+      },
+      {
+        "dishName": "Garlic Knots",
+        "price": 4.29,
+        "image": "https://ohsweetbasil.com/wp-content/uploads/one-hour-garlic-knots-6-scaled.jpg"
+      },
+      {
+        "dishName": "Cinnamon Swirl Brioche",
+        "price": 5.25,
+        "image": "https://sarahscoopeats.com/wp-content/uploads/2023/07/cinnamon-swirl-brioche-french-toast-recipe.jpg"
+      },
+      {
+        "dishName": "Italian Baguette",
+        "price": 3.99,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2017/10/Tomato-Baguette-Pizza_EXPS_SDDJ17_40299_C08_25_7b.jpg"
+      },
+      {
+        "dishName": "Rosemary Olive Oil Focaccia",
+        "price": 6.95,
+        "image": "https://i.pinimg.com/736x/fd/03/6e/fd036eedb8412917259b8468bb8bde01.jpg"
+      }
+    ],
+    "image": "https://cdn.akamai.steamstatic.com/steam/apps/2177320/capsule_616x353.jpg?t=1667724924",
+    "storeId": 107
+  },
+  {
+    "cityName": "San Francisco",
+    "storeName": "Sakura Sushi Bar",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Philadelphia Roll",
+        "price": 12.95,
+        "image": "https://img.buzzfeed.com/thumbnailer-prod-us-east-1/696c264b93bf424ba0b8a0abdde8de80/BFV30104_SushiDinnerForTwo_FB_NiNo_Final.jpg"
+      },
+      {
+        "dishName": "California Maki",
+        "price": 10.5,
+        "image": "https://c8.alamy.com/comp/H9NT9A/california-maki-dish-japanese-food-H9NT9A.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Roll",
+        "price": 11.25,
+        "image": "https://thewoodenskillet.com/wp-content/uploads/2023/06/spicy-tuna-roll-recipe-2.jpg"
+      },
+      {
+        "dishName": "Salmon Nigiri",
+        "price": 14.95,
+        "image": "https://izzycooking.com/wp-content/uploads/2020/10/Salmon-Nigiri-1-683x1024.jpg"
+      },
+      {
+        "dishName": "Tempura Shrimp Roll",
+        "price": 13.5,
+        "image": "https://norecipes.com/wp-content/uploads/2022/02/shrimp-tempura-roll-004-720x720.jpg"
+      },
+      {
+        "dishName": "Dragon Roll",
+        "price": 12.75,
+        "image": "https://www.afarmgirlsdabbles.com/wp-content/uploads/2022/10/Dragon-Roll38797_1400-500x749.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/aa/34/12/aa3412f3981777f2b51f2b57f4aa2571.png",
+    "storeId": 108
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Megane's Kitchen",
+    "category": "Japanese-Cuisine",
+    "products": [
+      {
+        "dishName": "Miso Soup with Wakame Seaweed",
+        "price": 7.99,
+        "image": "https://chefjacooks.com/wp-content/uploads/2022/11/wakame-miso-soup-5.jpg"
+      },
+      {
+        "dishName": "Grilled Salmon Sashimi",
+        "price": 18.99,
+        "image": "https://www.cookingclassy.com/wp-content/uploads/2018/05/grilled-salmon-3.jpg"
+      },
+      {
+        "dishName": "Megane's Special Cannellini Beans",
+        "price": 12.99,
+        "image": "https://gypsyplate.com/wp-content/uploads/2022/10/cannellini-beans_02-1024x1536.jpg"
+      },
+      {
+        "dishName": "Tonkatsu with Rice and Broccoli",
+        "price": 14.99,
+        "image": "https://preview.redd.it/tonkatsu-broccoli-with-mushrooms-and-chicken-fried-rice-v0-9qt3p11rnnka1.jpg?width=1080&crop=smart&auto=webp&s=a621ad341a3ad251da5e22f6769a7c96bef906dd"
+      },
+      {
+        "dishName": "Bento Box with Chicken Katsu and Tempura",
+        "price": 16.99,
+        "image": "https://i.pinimg.com/originals/07/db/b0/07dbb08108c299e8856e594ecde4c6f9.jpg"
+      },
+      {
+        "dishName": "Yakiitori (Grilled Chicken Skewers)",
+        "price": 10.99,
+        "image": "https://tiffycooks.com/wp-content/uploads/2021/03/Japanese-Chicken-Skewers-.png"
+      }
+    ],
+    "image": "https://img.freepik.com/premium-vector/kitchen-logo-design-home-chef-logo-cooking-logo-design_742418-555.jpg?w=2000",
+    "storeId": 109
+  },
+  {
+    "cityName": "Paris",
+    "storeName": "Bistro des Arts",
+    "category": "French cuisine",
+    "products": [
+      {
+        "dishName": "Cornichons Salad",
+        "price": 8.99,
+        "image": "https://www.gloriagoodtaste.com/wp-content/uploads/2019/07/IMG_5166.jpg"
+      },
+      {
+        "dishName": "Steak au Poivre",
+        "price": 19.95,
+        "image": "https://assets.bonappetit.com/photos/606cdd1ea56a3b6925ed48dc/1:1/w_2560%2Cc_limit/Cook-This-Book-Molly-Baz-Steak.jpg"
+      },
+      {
+        "dishName": "Ratatouille de Provence",
+        "price": 12.5,
+        "image": "https://thumbs.dreamstime.com/b/ratatouille-traditional-french-provencal-vegetable-dish-cooked-oven-homemade-preparation-recipe-healthy-diet-71795287.jpg"
+      },
+      {
+        "dishName": "Tournedos Rossini",
+        "price": 32,
+        "image": "https://www.jamesmartinchef.co.uk/wp-content/uploads/TX32-JAMES-MARTIN-TOURNEDOS-ROSSINI.jpg"
+      },
+      {
+        "dishName": "Bouillabaisse Marseillaise",
+        "price": 14.95,
+        "image": "http://img.taste.com.au/xevn8hx3/taste/2016/11/bouillabaisse-78546-1.jpeg"
+      },
+      {
+        "dishName": "Mille-Feuille au Caramel",
+        "price": 6.5,
+        "image": "https://preview.redd.it/homemade-salted-caramel-mille-feuille-v0-mao9zts8ik2a1.jpg?width=1080&crop=smart&auto=webp&s=12314813559001c4f0ac438b4035f3f8a21d4feb"
+      }
+    ],
+    "image": "http://www.bistrodesarts.ae/wp-content/uploads/2018/08/bistrod-logo-4.png",
+    "storeId": 110
+  },
+  {
+    "cityName": "New York",
+    "storeName": "Bella Vita",
+    "category": "Italian",
+    "products": [
+      {
+        "dishName": "Linguine With Clams",
+        "price": 29.95,
+        "image": "http://assets.marthastewart.com/styles/wmax-520-highdpi/d28/tvm2161_050307_linguineclams/tvm2161_050307_linguineclams_xl.jpg?itok=bz5bw0xD"
+      },
+      {
+        "dishName": "Grilled Chicken Parmesan",
+        "price": 18.5,
+        "image": "https://www.dontgobaconmyheart.co.uk/wp-content/uploads/2020/08/baked-chicken-parmesan.jpg"
+      },
+      {
+        "dishName": "Veal Piccata",
+        "price": 24.75,
+        "image": "https://www.thespruceeats.com/thmb/tfvgX58Pq7RmaO2nksQxXFABD9g=/4048x2696/filters:fill(auto,1)/classic-veal-piccata-recipe-995302-hero-01-8066d25164ce498f85ff5f4634e6e113.jpg"
+      },
+      {
+        "dishName": "Spaghetti Bolognese",
+        "price": 16.95,
+        "image": "http://www.lipstickblogger.com/wp-content/uploads/2017/01/Spaghetti_1-1024x1024.jpg"
+      },
+      {
+        "dishName": "Cannoli Siciliani",
+        "price": 7.5,
+        "image": "https://st4.depositphotos.com/20524830/25786/i/1600/depositphotos_257861884-stock-photo-cannoli-siciliani-sicilian-pastry-dish.jpg"
+      },
+      {
+        "dishName": "Eggplant Parmesan",
+        "price": 19.25,
+        "image": "https://cdn.apartmenttherapy.info/image/fetch/f_auto,q_auto:eco/https://storage.googleapis.com/gen-atmedia/3/2018/08/c024bcfedd6354f883f878c103ce47b51e919697.jpeg"
+      }
+    ],
+    "image": "https://www.mediainfoline.com/wp-content/uploads/2022/12/Bella-Vita-Luxury-logo.jpg",
+    "storeId": 111
+  },
+  {
+    "cityName": "Bangkok",
+    "storeName": "Trystan's Thai Kitchen",
+    "category": "Thai Cuisine",
+    "products": [
+      {
+        "dishName": "Tom Yum Soup",
+        "price": 8.99,
+        "image": "https://i0.wp.com/www.valerieskeepers.com/wp-content/uploads/2014/11/Tom-Yum-Soup_10-1-sur-1.jpg"
+      },
+      {
+        "dishName": "Pad Thai with Shrimp",
+        "price": 12.95,
+        "image": "https://www.tasteofhome.com/wp-content/uploads/2018/06/Shrimp-Pad-Thai_EXPS_THN18_45967_D05_23_6b.jpg"
+      },
+      {
+        "dishName": "Green Curry Chicken",
+        "price": 10.99,
+        "image": "https://i.pinimg.com/originals/bc/20/a2/bc20a2e7af893d0a95f2230c1bfb318c.png"
+      },
+      {
+        "dishName": "Trystan's Special Lemongrass",
+        "price": 14.95,
+        "image": "https://poshjournal.com/wp-content/uploads/2021/01/vietnamese-lemongrass-chicken-stir-fry-7.jpg"
+      },
+      {
+        "dishName": "Massaman Beef Curry",
+        "price": 11.99,
+        "image": "https://www.kitchensanctuary.com/wp-content/uploads/2019/10/Beef-Massaman-square-1200-1459.jpg"
+      },
+      {
+        "dishName": "Grilled Pork Satay",
+        "price": 9.95,
+        "image": "https://thumbs.dreamstime.com/z/pork-satay-grilled-pork-served-peanut-sauce-sweet-sour-sauce-pork-satay-grilled-pork-served-peanut-sauce-sweet-158332938.jpg"
+      },
+      {
+        "dishName": "Spicy Basil Stir Fry",
+        "price": 10.49,
+        "image": "https://www.halfbakedharvest.com/wp-content/uploads/2021/08/25-Minute-Black-Pepper-Jalapen%CC%83o-Basil-Chicken-Stir-Fry-1.jpg"
+      }
+    ],
+    "image": "https://d2gqo3h0psesgi.cloudfront.net/auto/thai-kitchen-logo.png",
+    "storeId": 112
+  },
+  {
+    "cityName": "Tokyo",
+    "storeName": "Sushi Yamato",
+    "category": "Japanese",
+    "products": [
+      {
+        "dishName": "Hijiki Salad",
+        "price": 8.99,
+        "image": "https://japan.recipetineats.com/wp-content/uploads/2018/02/Hijiki_Salad_0201.jpg"
+      },
+      {
+        "dishName": "Salmon Sashimi",
+        "price": 12.95,
+        "image": "https://static.vecteezy.com/system/resources/previews/001/259/559/large_2x/salmon-sashimi-dish-free-photo.jpg"
+      },
+      {
+        "dishName": "Tofu Tempura",
+        "price": 10.5,
+        "image": "https://i.pinimg.com/originals/4b/d8/ad/4bd8ad6d91547ee2d7a82489940af975.jpg"
+      },
+      {
+        "dishName": "Spicy Tuna Roll",
+        "price": 14.25,
+        "image": "https://thewoodenskillet.com/wp-content/uploads/2023/06/spicy-tuna-roll-recipe-2.jpg"
+      },
+      {
+        "dishName": "Miso Soup",
+        "price": 4.95,
+        "image": "https://www.thespruceeats.com/thmb/q5pzZZKO021eP9s4x_-Mq6m_I8Q=/4494x3000/filters:fill(auto,1)/basic-miso-soup-3377886_09-5b3f7fb6c9e77c00378bf68f.jpg"
+      },
+      {
+        "dishName": "Gyoza (Pan-Fried Dumplings)",
+        "price": 11.99,
+        "image": "https://khinskitchen.com/wp-content/uploads/2020/07/gyoza-facebook-min.jpg"
+      }
+    ],
+    "image": "https://i.pinimg.com/originals/61/d7/7f/61d77fef0bb6b4f9aab01e79ee195790.jpg",
+    "storeId": 113
   }
 ]
+

--- a/stores/scripts/gen-stores.ts
+++ b/stores/scripts/gen-stores.ts
@@ -4,11 +4,11 @@ import { Ollama } from "ollama";
 import { z } from "zod";
 import { faker } from "@faker-js/faker";
 
-const GOOGLE_API_KEY = process.env.GOOGLE_API_KEY!;
-const GOOGLE_CX = process.env.GOOGLE_CX!;
-
+const BING_API_KEY = process.env.BING_API_KEY!;
 const ollama = new Ollama({ host: process.env.OLLAMA_HOST! });
-const storesToGenerate = 15;
+
+const storesToGenerate = 100;
+const datastorePath = "data/stores.json";
 const dishPlaceholder =
   "https://cdn-icons-png.flaticon.com/512/4901/4901689.png";
 
@@ -29,13 +29,12 @@ const ModelStoreResponse = z.object({
 const generateStore = async (): Promise<typeof ModelStoreResponse._type> => {
   const message = {
     role: "user",
-    content: `Generate one that sells ${faker.food.dish()}}`,
+    content: `Generate one that sells ${faker.food.dish()}`,
   };
   const response = await ollama.chat({
     model: "gen-stores",
     messages: [message],
   });
-
   try {
     const possibleStore = JSON.parse(response.message.content);
     return ModelStoreResponse.parse(possibleStore);
@@ -50,76 +49,106 @@ const generateStore = async (): Promise<typeof ModelStoreResponse._type> => {
 const createModel = async () => {
   const model = `
     FROM llama3.1
-    SYSTEM "You are a model that generates a JSON containing information about restaurants and their dishes. The JSON must include the fields: "cityName", "storeName", "category", and "products". Each product in "products" must include "dishName" and "price". The number of dishes in "products" should be random, but always at least 3. Generate realistic and varied data. Respond with the requested JSON only, without any additional explanations or text."
+    SYSTEM "You are a model that generates a JSON containing information about restaurants and their dishes. The JSON must include the fields: "cityName", "storeName", "category", and "products". Each product in "products" must include "dishName" and "price". The number of dishes in "products" should be random, but always at least 5. Generate realistic and varied data. Respond with the requested JSON only, without any additional explanations or text."
     `;
-
   await ollama.create({ model: "gen-stores", modelfile: model });
 };
 
-const addImageToStore = async (store: typeof ModelStoreResponse._type) => {
-  const storeWithImage = { ...store };
-
-  storeWithImage.image = await findImage("logo " + store.storeName);
-
-  storeWithImage.products = await Promise.all(
-    store.products.map(async (product) => {
-      if (!product.image) {
-        product.image = await findImage(product.dishName + " dish");
-      }
-
-      return product;
-    })
-  );
-
-  return storeWithImage;
-};
-
 const findImage = async (query: string): Promise<string> => {
-  const url = new URL("https://www.googleapis.com/customsearch/v1");
-  url.searchParams.append("key", GOOGLE_API_KEY);
-  url.searchParams.append("cx", GOOGLE_CX);
-  url.searchParams.append(
-    "rights",
-    "cc_publicdomain,cc_attribute,cc_sharealike,cc_noncommercial,cc_nonderived"
-  );
-  url.searchParams.append("searchType", "image");
+  const url = new URL("https://api.bing.microsoft.com/v7.0/images/search");
   url.searchParams.append("q", query);
+  url.searchParams.append("count", "1");
 
-  const response = await fetch(url.toString());
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      "Ocp-Apim-Subscription-Key": BING_API_KEY,
+      Accept: "application/json",
+    },
+  });
 
   if (response.status === 429) {
-    console.error("Google API rate limit exceeded");
-    return dishPlaceholder;
+    console.error("Bing API rate limit exceeded, waiting...");
+    await new Promise((resolve) => setTimeout(resolve, 1000)); // Wait 1 second
+    return findImage(query); // Retry
   }
 
   const data = await response.json();
 
-  if (!data.items || data.items.length === 0) {
+  if (!data.value || data.value.length === 0) {
     console.warn(`No image found for query: ${query}`);
-    console.warn(response);
     return dishPlaceholder;
   }
 
-  return data.items[0].link;
+  return data.value[0].contentUrl;
 };
 
-let currentStoreId = 1;
+const addImageToStore = async (store: typeof ModelStoreResponse._type) => {
+  const storeWithImage = { ...store };
+  const imagePromises = [findImage("logo " + store.storeName)];
 
-const addStoreId = (store: any) => {
-  store.storeId = currentStoreId++;
+  storeWithImage.products.forEach((product) => {
+    imagePromises.push(findImage(product.dishName + " dish"));
+  });
+
+  // Rate limiting - process 3 images at a time at most.
+  const results = [] as string[];
+  for (let i = 0; i < imagePromises.length; i += 3) {
+    const chunk = imagePromises.slice(i, i + 3);
+    const chunkResults = await Promise.all(chunk);
+    results.push(...chunkResults);
+    if (i + 3 < imagePromises.length) {
+      await new Promise((resolve) => setTimeout(resolve, 334)); // Wait for the next second (with a bit of buffer).
+    }
+  }
+
+  storeWithImage.image = results.shift()!;
+  storeWithImage.products = storeWithImage.products.map((product, index) => ({
+    ...product,
+    image: (results as string[])[index],
+  }));
+
+  return storeWithImage;
+};
+
+const readExistingStores = (): any[] => {
+  try {
+    if (fs.existsSync(datastorePath)) {
+      const existingData = fs.readFileSync(datastorePath, "utf8");
+      return existingData ? JSON.parse(existingData) : [];
+    }
+    return [];
+  } catch (error) {
+    console.error("Error reading existing stores:", error);
+    return [];
+  }
+};
+
+const appendStore = (store: any) => {
+  const existingStores = readExistingStores();
+  store.storeId =
+    existingStores.length > 0
+      ? Math.max(...existingStores.map((s) => s.storeId)) + 1
+      : 1;
+  existingStores.push(store);
+  fs.mkdirSync("data", { recursive: true });
+  fs.writeFileSync(datastorePath, JSON.stringify(existingStores, null, 2));
+  console.log(`Store ${store.storeName} added (ID: ${store.storeId})`);
   return store;
 };
 
 async function main() {
   await createModel();
 
-  const stores = await Promise.all(
-    Array.from({ length: storesToGenerate }).map(() =>
-      generateStore().then(addImageToStore).then(addStoreId)
-    )
-  );
-
-  fs.writeFileSync("data/stores.json", JSON.stringify(stores, null, 2));
+  for (let i = 0; i < storesToGenerate; i++) {
+    try {
+      const store = await generateStore();
+      const storeWithImage = await addImageToStore(store);
+      appendStore(storeWithImage);
+    } catch (error) {
+      console.error(`Error generating store #${i + 1}:`, error);
+    }
+  }
 }
 
-main();
+main().catch(console.error);


### PR DESCRIPTION
This commit expands the store data by increasing the number of generated
stores from 25 to 100 and adds at least 5 products to each generated
store. It also replaces the Google Custom Search API with the Bing
Image Search API for finding store and dish images, implementing rate
limiting to avoid exceeding API quotas. Error handling and logging have
been improved to provide better feedback during the generation process.
Additionally, existing store data is now preserved and new stores are
appended, ensuring data integrity and preventing accidental overwrites.
Finally, generated files are saved in a data sub-directory to organize
project files better.

this is related to the issue #33.
